### PR TITLE
Explore reporting Ninja builds logs to investigate timing problems

### DIFF
--- a/Common/Common.ps1
+++ b/Common/Common.ps1
@@ -34,3 +34,22 @@ function Get-MemberValue {
     )
     (Select-Object -InputObject $InputObject -ExpandProperty $Name -ErrorAction SilentlyContinue) ?? $Or
 }
+
+<#
+ .Synopsis
+  Performs linear interpolation from the first color to the second.
+#>
+function ColorInterpolation{
+    param(
+        [System.Drawing.Color]$FromColor,
+        [System.Drawing.Color]$ToColor,
+        [Single]$T
+    )
+
+    $Alpha = $FromColor.A + (($ToColor.A - $FromColor.A) * $T)
+    $Red = $FromColor.R + (($ToColor.R - $FromColor.R) * $T)
+    $Green = $FromColor.G + (($ToColor.G - $FromColor.G) * $T)
+    $Blue = $FromColor.B + (($ToColor.B - $FromColor.B) * $T)
+
+    [System.Drawing.Color]::FromArgb($Alpha, $Red, $Green, $Blue)
+}

--- a/Common/Console.ps1
+++ b/Common/Console.ps1
@@ -1,0 +1,122 @@
+#----------------------------------------------------------------------------------------------------------------------
+# MIT License
+#
+# Copyright (c) 2021 Mark Schofield
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#----------------------------------------------------------------------------------------------------------------------
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$CSharpCode = @'
+private const uint GENERIC_READ = 0x80000000;
+private const uint GENERIC_WRITE = 0x40000000;
+private const uint FILE_SHARE_READ = 0x00000001;
+private const uint FILE_SHARE_WRITE = 0x00000002;
+private const uint OPEN_EXISTING = 3;
+
+[DllImport("kernel32.dll", SetLastError = true, CharSet=CharSet.Unicode, ExactSpelling = true)]
+private static extern SafeFileHandle CreateFileW(string fileName, uint desiredAccess, uint shareMode, IntPtr securityAttributes, uint creationDisposition, uint flagsAndAttributes, IntPtr templateFile);
+
+[DllImport("kernel32.dll", SetLastError = true, ExactSpelling = true)]
+public static extern uint GetConsoleMode(SafeFileHandle consoleHandle, out uint mode);
+
+public static SafeFileHandle GetConIn()
+{
+    SafeFileHandle fileHandle = CreateFileW("CONIN$", GENERIC_READ, FILE_SHARE_READ, IntPtr.Zero, OPEN_EXISTING, 0, IntPtr.Zero);
+    if (fileHandle.IsInvalid)
+    {
+        throw new System.ComponentModel.Win32Exception();
+    }
+    return fileHandle;
+}
+
+public static SafeFileHandle GetConOut()
+{
+    SafeFileHandle fileHandle = CreateFileW("CONOUT$", GENERIC_READ | GENERIC_WRITE, FILE_SHARE_WRITE, IntPtr.Zero, OPEN_EXISTING, 0, IntPtr.Zero);
+    if (fileHandle.IsInvalid)
+    {
+        throw new System.ComponentModel.Win32Exception();
+    }
+    return fileHandle;
+}
+'@
+
+$script:Console = $null
+$script:IsVirtualTerminalProcessingEnabled = $null
+
+function GetConsole {
+    if (-not $script:Console) {
+        $script:Console = Add-Type -Language CSharp -MemberDefinition $CSharpCode -Name NativeMethods -Namespace Console -PassThru -UsingNamespace 'Microsoft.Win32.SafeHandles' -ErrorAction SilentlyContinue
+        if (-not $script:Console) {
+            throw "Fatal error: Unable to compile the necessary C# code."
+        }
+    }
+    $script:Console
+}
+
+<#
+ .Synopsis
+  Returns whether virtual terminal processing is enabled for the current console.
+
+ .Outputs
+ `$true` if virtual terminal processing is enabled, `$false` otherwise.
+#>
+function IsVirtualTerminalProcessingEnabled {
+    if ($null -eq $script:IsVirtualTerminalProcessingEnabled) {
+        $Console = GetConsole
+        $ConOut = $Console::GetConOut();
+        try {
+            $ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x04
+            $Mode = 0
+            if (($Console::GetConsoleMode($ConOut, [ref] $Mode) -eq 0) -or
+                (-not($Mode -band $ENABLE_VIRTUAL_TERMINAL_PROCESSING))) {
+                $script:IsVirtualTerminalProcessingEnabled = $false
+            } else {
+                $script:IsVirtualTerminalProcessingEnabled = $true
+            }
+        } finally {
+            $ConOut.Close()
+        }
+    }
+    $script:IsVirtualTerminalProcessingEnabled;
+}
+
+<#
+ .Synopsis
+  Returns the control codes to set the foreground color to the specified value.
+#>
+function ColorToControlCode{
+    param(
+        [System.Drawing.Color]$Color
+    )
+    if (IsVirtualTerminalProcessingEnabled) {
+        "`e" + '[38;2;' + ('{0:d3}' -f $Color.R) + ';' + ('{0:d3}' -f $Color.G) + ';' + ('{0:d3}' -f $Color.B) + 'm'
+    }
+}
+
+<#
+ .Synopsis
+  Returns the control codes to reset foreground attributes, if virtual terminal processing is enable.
+#>
+function ResetForegroundControlCode{
+    if (IsVirtualTerminalProcessingEnabled) {
+        "`e[39m"
+    }
+}

--- a/Common/Ninja.ps1
+++ b/Common/Ninja.ps1
@@ -1,0 +1,115 @@
+#----------------------------------------------------------------------------------------------------------------------
+# MIT License
+#
+# Copyright (c) 2021 Mark Schofield
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#----------------------------------------------------------------------------------------------------------------------
+#Requires -PSEdition Core
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+. $PSScriptRoot/Common.ps1
+. $PSScriptRoot/Console.ps1
+
+<#
+ .Synopsis
+  Tries to parse the specified Ninja log.
+
+ .Outputs
+ The entries from the Ninja log.
+#>
+function TryParseNinjaLog {
+    [CmdletBinding()]
+    param(
+        [string] $NinjaLogPath
+    )
+    if (Test-Path -Path $NinjaLogPath -PathType Leaf) {
+        Get-Content $NinjaLogPath |
+            Where-Object {$_[0] -ne '#'} |
+            ForEach-Object {
+                $Tokens = $_ -split "\t"
+                [int]$StartTime = $Tokens[0]
+                [int]$EndTime = $Tokens[1]
+                [pscustomobject]@{
+                    StartTime=$StartTime
+                    EndTime=$EndTime
+                    WriteTime=([long]$Tokens[2])
+                    File=$Tokens[3]
+                    CommandHash=$Tokens[4]
+                    Duration=($EndTime - $StartTime)
+                }
+            }
+    }
+}
+
+$FileTimeOffset = [long]12622770400 * [long]10000000
+
+<#
+ .Synopsis
+  Converts the specified Ninja log time representation into a [datetime].
+
+ .Notes
+ This function is currently Windows-only.
+#>
+function ConvertFrom-NinjaTime {
+    param(
+        $NinjaTime
+    )
+    [datetime]::FromFileTime([long]$NinjaTime + $FileTimeOffset)
+}
+
+<#
+ .Synopsis
+  Converts the specified [datetime] into Ninja log time representation.
+
+ .Notes
+ This function is currently Windows-only.
+#>
+function ConvertTo-NinjaTime {
+    param(
+        [datetime]$Time
+    )
+    $Time.ToFileTime() - $FileTimeOffset;
+}
+
+function Report-NinjaBuild {
+    param(
+        [string] $NinjaLogPath,
+        [datetime] $BuildStartTime
+    )
+    $BuildStartNinjaTime = ConvertTo-NinjaTime $BuildStartTime
+    $Entries = (TryParseNinjaLog $NinjaLogPath) |
+        Where-Object {$_.WriteTime -ge $BuildStartNinjaTime}
+    $Statistics = $Entries | Measure-Object -Property Duration -Maximum
+    if (-not $Statistics) {
+        return
+    }
+    $MaximumDuration = $Statistics.Maximum
+    [System.Drawing.Color]$WorstColor = "#ff0000"
+    [System.Drawing.Color]$BestColor = "#00ff00"
+    $Entries |
+        Sort-Object -Property Duration |
+        ForEach-Object {
+            $Color = ColorInterpolation $BestColor $WorstColor ($_.Duration / $MaximumDuration)
+            [string]$_.Duration + ' ' + (ColorToControlCode $Color) + $_.File + (ResetForegroundControlCode)
+        }
+}
+


### PR DESCRIPTION
When the Ninja build stalls it's not clear what files are currently being processed. And my build has stalls. The .ninja_log has timings of the files that were written during the build, so the PSCMake module could read the log, sort it and report out which files take the longest. This PR explores that - with some gratuitous colored console output - to see if it is useful. Add `-Report` to a `Build-CMakeBuild` command-line and - if the build is a ninja build - the files that were written to the build will be written out, along with their timings.