### PR TITLE
Verbose PowerShell should launch a verbose CMake

### DIFF
--- a/PSCMake.psm1
+++ b/PSCMake.psm1
@@ -151,7 +151,13 @@ function Configure-CMakeBuild {
 
         $CMakeArguments = @(
             '--preset', $Preset
+            if ($VerbosePreference) {
+                '--log-level=VERBOSE'
+            }
         )
+
+        Write-Verbose "CMake Arguments: $CMakeArguments"
+
         & $CMake @CMakeArguments
     }
 }
@@ -188,6 +194,7 @@ function Configure-CMakeBuild {
    Build-CMakeBuild -Presets windows-x64,windows-x86 -Configurations Release -Targets HelperLibrary
 #>
 function Build-CMakeBuild {
+    [CmdletBinding()]
     param (
         [Parameter(Position = 0)]
         [string[]] $Presets,
@@ -236,6 +243,8 @@ function Build-CMakeBuild {
                 '--target', $Targets
             }
         )
+
+        Write-Verbose "CMake Arguments: $CMakeArguments"
 
         if (-not $Configurations) {
             $StartTime = [datetime]::Now


### PR DESCRIPTION
If '-verbose' is passed to the CmdLet, configure CMake to `--log-level=VERBOSE` as a mechanism for controlling CMake output. Plumbing through a separate parameter for the CMake log-level would be an alternative, but leveraging the CMake `$VerbosityPreference` seems reasonable.