### PR TITLE
Refactor 'ResolvePresets' to support different preset types

### DIFF
--- a/Common/CMake.ps1
+++ b/Common/CMake.ps1
@@ -123,7 +123,6 @@ function GetCMake {
                 break
             }
         }
-
         if (-not $CMake) {
             Write-Error "Unable to find CMake."
         }
@@ -134,20 +133,23 @@ function GetCMake {
 function ResolvePresets {
     param (
         $CMakePresetsJson,
-        $BuildPresetName
+
+        [ValidateSet('buildPresets', 'testPresets')]
+        $PresetType,
+
+        $PresetName
     )
-
-    $BuildPreset = $CMakePresetsJson.buildPresets | Where-Object { $_.name -eq $BuildPresetName }
-    if (-not $BuildPreset) {
-        Write-Error "Unable to find build preset '$Preset' in $script:CMakePresetsPath"
+    $PresetJson = $CMakePresetsJson.$PresetType | Where-Object { $_.name -eq $PresetName }
+    if (-not $PresetJson) {
+        Write-Error "Unable to find $PresetType '$Preset' in $script:CMakePresetsPath"
     }
 
-    $ConfigurePreset = $CMakePresetsJson.configurePresets | Where-Object { $_.name -eq $BuildPreset.configurePreset }
-    if (-not $ConfigurePreset) {
-        Write-Error "Unable to find configuration preset '$($BuildPreset.configurePreset)' in $script:CMakePresetsPath"
+    $ConfigurePresetJson = $CMakePresetsJson.configurePresets | Where-Object { $_.name -eq $PresetJson.configurePreset }
+    if (-not $ConfigurePresetJson) {
+        Write-Error "Unable to find configuration preset '$($PresetJson.configurePreset)' in $script:CMakePresetsPath"
     }
 
-    $BuildPreset, $ConfigurePreset
+    $PresetJson, $ConfigurePresetJson
 }
 
 function ResolvePresetProperty {

--- a/PSCMake.psm1
+++ b/PSCMake.psm1
@@ -85,7 +85,7 @@ function BuildTargetsCompleter {
     )
     $CMakePresetsJson = GetCMakePresets -Silent
     $Preset = $FakeBoundParameters.Presets | Select-Object -First 1
-    $BuildPreset, $ConfigurePreset = ResolvePresets $CMakePresetsJson $Preset
+    $BuildPreset, $ConfigurePreset = ResolvePresets $CMakePresetsJson 'buildPresets' $Preset
     $BinaryDirectory = GetBinaryDirectory $CMakePresetsJson $ConfigurePreset
     $CMakeCodeModel = Get-CMakeBuildCodeModel $BinaryDirectory
 
@@ -224,7 +224,7 @@ function Build-CMakeBuild {
 
     $CMake = GetCMake
     foreach ($Preset in $Presets) {
-        $BuildPreset, $ConfigurePreset = ResolvePresets $CMakePresetsJson $Preset
+        $BuildPreset, $ConfigurePreset = ResolvePresets $CMakePresetsJson 'buildPresets' $Preset
         $BinaryDirectory = GetBinaryDirectory $CMakePresetsJson $ConfigurePreset
         $CMakeCacheFile = Join-Path -Path $BinaryDirectory -ChildPath 'CMakeCache.txt'
 
@@ -277,7 +277,7 @@ function Write-CMakeBuild {
         [string] $As
     )
     $CMakePresetsJson = GetCMakePresets
-    $BuildPreset, $ConfigurePreset = ResolvePresets $CMakePresetsJson $Preset
+    $BuildPreset, $ConfigurePreset = ResolvePresets $CMakePresetsJson 'buildPresets' $Preset
     $BinaryDirectory = GetBinaryDirectory $ConfigurePreset
     $CodeModel = Get-CMakeBuildCodeModel $BinaryDirectory
     $CodeModelDirectory = Get-CMakeBuildCodeModelDirectory $BinaryDirectory
@@ -289,6 +289,5 @@ Register-ArgumentCompleter -CommandName Build-CMakeBuild -ParameterName Presets 
 Register-ArgumentCompleter -CommandName Build-CMakeBuild -ParameterName Configurations -ScriptBlock $function:BuildConfigurationsCompleter
 Register-ArgumentCompleter -CommandName Build-CMakeBuild -ParameterName Targets -ScriptBlock $function:BuildTargetsCompleter
 Register-ArgumentCompleter -CommandName Configure-CMakeBuild -ParameterName Presets -ScriptBlock $function:ConfigurePresetsCompleter
-
 Register-ArgumentCompleter -CommandName Write-CMakeBuild -ParameterName Preset -ScriptBlock $function:BuildPresetsCompleter
 Register-ArgumentCompleter -CommandName Write-CMakeBuild -ParameterName Configuration -ScriptBlock $function:BuildConfigurationsCompleter


### PR DESCRIPTION
In order to accommodate 'testPresets' - in addition to 'buildPresets' - refactor ResolvePresets to search different preset types. 