### PR TITLE
BuildConfigurationsCompleter should filter configurations by $WordToComplete

### DIFF
--- a/PSCMake.psm1
+++ b/PSCMake.psm1
@@ -68,7 +68,7 @@ function BuildConfigurationsCompleter {
         'Debug'
         'RelWithDebInfo'
         'MinSizeRel'
-    )
+    ) | Where-Object { $_ -ilike "$WordToComplete*" }
 }
 
 <#

--- a/Tests/BuildConfigurationsCompleter.Tests.ps1
+++ b/Tests/BuildConfigurationsCompleter.Tests.ps1
@@ -1,0 +1,27 @@
+#Requires -PSEdition Core
+
+BeforeAll {
+    . $PSScriptRoot/TestUtilities.ps1
+    Import-Module -Force $PSScriptRoot/../PSCMake.psd1 -DisableNameChecking
+
+    $CMakePresetsJson = Get-Content (Join-Path -Path $PSScriptRoot -ChildPath 'CMakePresets.Single.json') |
+        ConvertFrom-Json
+    Mock -ModuleName PSCMake GetCMakePresets { $CMakePresetsJson }
+}
+
+Describe 'BuildConfigurationsCompleter' {
+    It 'Returns the default configurations when no preset is specified' {
+        $Completions = Get-CommandCompletions "Build-CMakeBuild -Configurations "
+        $Completions.CompletionMatches.Count | Should -Be 4
+        $Completions.CompletionMatches[0].CompletionText | Should -Be 'Release'
+        $Completions.CompletionMatches[1].CompletionText | Should -Be 'Debug'
+        $Completions.CompletionMatches[2].CompletionText | Should -Be 'RelWithDebInfo'
+        $Completions.CompletionMatches[3].CompletionText | Should -Be 'MinSizeRel'
+    }
+
+    It 'Returns the default configurations when no preset is specified, filtered by the word to complete' {
+        $Completions = Get-CommandCompletions "Build-CMakeBuild -Configurations D"
+        $Completions.CompletionMatches.Count | Should -Be 1
+        $Completions.CompletionMatches[0].CompletionText | Should -Be 'Debug'
+    }
+}

--- a/Tests/BuildPresetsCompleter.Tests.ps1
+++ b/Tests/BuildPresetsCompleter.Tests.ps1
@@ -1,0 +1,25 @@
+#Requires -PSEdition Core
+
+BeforeAll {
+    . $PSScriptRoot/TestUtilities.ps1
+    Import-Module -Force $PSScriptRoot/../PSCMake.psd1 -DisableNameChecking
+
+    $CMakePresetsJson = Get-Content (Join-Path -Path $PSScriptRoot -ChildPath 'CMakePresets.Single.json') |
+        ConvertFrom-Json
+    Mock -ModuleName PSCMake GetCMakePresets { $CMakePresetsJson }
+}
+
+Describe 'BuildPresetsCompleter' {
+    It 'Returns the presets from the discovered presets file, in the order that they are defined' {
+        $Completions = Get-CommandCompletions "Build-CMakeBuild -Preset "
+        $Completions.CompletionMatches.Count | Should -Be 2
+        $Completions.CompletionMatches[0].CompletionText | Should -Be 'windows-x64'
+        $Completions.CompletionMatches[1].CompletionText | Should -Be 'windows-arm'
+    }
+
+    It 'Returns the presets from the discovered presets file, filtered by the word to complete' {
+        $Completions = Get-CommandCompletions "Build-CMakeBuild -Preset windows-a"
+        $Completions.CompletionMatches.Count | Should -Be 1
+        $Completions.CompletionMatches[0].CompletionText | Should -Be 'windows-arm'
+    }
+}

--- a/Tests/CMakePresets.Single.json
+++ b/Tests/CMakePresets.Single.json
@@ -16,12 +16,27 @@
           "CMAKE_SYSTEM_VERSION": "10.0.19041.0"
         },
         "environment": {}
+      },
+      {
+        "name": "windows-arm",
+        "description": "A description for the 'windows-arm'",
+        "displayName": "Windows-only configuration",
+        "binaryDir": "${sourceDir}/__output/${presetName}",
+        "cacheVariables": {
+          "CMAKE_SYSTEM_PROCESSOR": "arm",
+          "CMAKE_SYSTEM_VERSION": "10.0.19041.0"
+        },
+        "environment": {}
       }
     ],
     "buildPresets": [
       {
         "name": "windows-x64",
         "configurePreset": "windows-x64"
+      },
+      {
+        "name": "windows-arm",
+        "configurePreset": "windows-arm"
       }
     ],
     "testPresets": [

--- a/Tests/ResolvePresetProperty.Tests.ps1
+++ b/Tests/ResolvePresetProperty.Tests.ps1
@@ -1,3 +1,5 @@
+#Requires -PSEdition Core
+
 BeforeAll {
     . $PSScriptRoot/../Common/CMake.ps1
 }

--- a/Tests/TestUtilities.ps1
+++ b/Tests/TestUtilities.ps1
@@ -1,0 +1,3 @@
+function Get-CommandCompletions([string] $InputScript) {
+    [System.Management.Automation.CommandCompletion]::CompleteInput($InputScript, $InputScript.Length, $null)
+}


### PR DESCRIPTION
`Build-CMakeBuild` and `Write-CMakeBuild` have a parameter for specifying the Configuration to use and an argument completer to resolve appropriate configurations. It currently doesn't have logic to actually resolve the configuration, and it doesn't respect a partial word that has been typed. This pull request fixes the latter, and is a first foray into adding argument completion tests to validate the partial matching, and to make it easier to add logic to resolve configurations.