### PR TITLE
The README.md badge should link to the workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ attempt at such tooling.
 At the minute the PowerShell module simply surfaces the ability to configure and build using CMake. By leveraging the
 CMake file API, the module is able to offer tab-completion when specifying targets to build.
 
-![build status](https://github.com/MarkSchofield/PSCMake/actions/workflows/ci.yaml/badge.svg)
+[![build status](https://github.com/MarkSchofield/PSCMake/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/MarkSchofield/PSCMake/actions/workflows/ci.yaml?query=branch%3Amain)
 
 ## Installation
 


### PR DESCRIPTION
Making the README.md badge link to the specific workflow. The URLs look like they *have* to be absolute - relative paths in markdown are interpreted as specifying files in the repo, not relative to the Github project root.