### PR TITLE
Implement "Build-CMakeBuild -Target" tab completion

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,9 +17,16 @@ indent_size = 4
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[{*.ps1,*.psm1}]
+[{*.ps1,*.psm1,*.psd1}]
 charset = utf-8
 indent_style = space
 indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.json]
+charset = utf-8
+indent_style = space
+indent_size = 2
 insert_final_newline = true
 trim_trailing_whitespace = true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 jobs:
   run-pester-tests:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 jobs:
   run-pester-tests:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/Common/Common.ps1
+++ b/Common/Common.ps1
@@ -53,3 +53,43 @@ function ColorInterpolation{
 
     [System.Drawing.Color]::FromArgb($Alpha, $Red, $Green, $Blue)
 }
+
+<#
+ .Synopsis
+  Checks whether the given file is newer than any subsequently specified files.
+#>
+function IsUpToDate($Target) {
+    $Dependencies = $args
+
+    $TargetItem = Get-Item -Path $Target -ErrorAction SilentlyContinue
+    if (-not $TargetItem) {
+        return $false;
+    }
+
+    foreach ($Dependency in $Dependencies) {
+        $DependentItem = Get-Item -Path $Dependency -ErrorAction SilentlyContinue
+        if ((-not $DependentItem) -or ($DependentItem.LastWriteTime -gt $TargetItem.LastWriteTime)) {
+            return $false;
+        }
+    }
+
+    $true
+}
+
+function Stash-Location($Location, $Scriptlet) {
+    Push-Location -Path $Location
+    try {
+        & $Scriptlet
+    } finally {
+        Pop-Location
+    }
+}
+
+function Touch($Item) {
+    Write-Verbose "Touch: $Item"
+    (Get-Item $Item).LastWriteTime = Get-Date
+}
+
+function DownloadFile([string] $Url, [string] $DownloadPath) {
+    [System.Net.WebClient]::new().DownloadFile($Url, $DownloadPath)
+}

--- a/Common/Ninja.ps1
+++ b/Common/Ninja.ps1
@@ -113,3 +113,27 @@ function Report-NinjaBuild {
         }
 }
 
+function Download-Ninja {
+    param(
+        [string] $OutputPath
+    )
+    $NinjaVersion = '1.10.2'
+    $NinjaArchiveUrl = "https://github.com/ninja-build/ninja/releases/download/v$NinjaVersion/ninja-win.zip"
+    $NinjaArchivePath = Join-Path -Path $OutputPath -ChildPath 'ninja-win.zip'
+    $NinjaArchiveSha256Hash = 'BBDE850D247D2737C5764C927D1071CBB1F1957DCABDA4A130FA8547C12C695F'
+    $NinjaExecutablePath = Join-Path -Path $OutputPath -ChildPath 'ninja.exe'
+
+    if (-not (IsUpToDate $NinjaExecutablePath $NinjaArchivePath)) {
+        Write-Verbose "Installing Ninja $NinjaVersion"
+        if (-not (IsUpToDate $NinjaArchivePath)) {
+            DownloadFile $NinjaArchiveUrl $NinjaArchivePath
+            if ($NinjaArchiveSha256Hash -ne (Get-FileHash -Path $NinjaArchivePath -Algorithm SHA256).Hash) {
+                Remove-Item -Force -Path $NinjaArchivePath
+                Write-Error "Invalid Hash"
+            }
+        }
+        Expand-Archive -Path $NinjaArchivePath -DestinationPath $OutputPath -Force
+        Touch $NinjaExecutablePath
+    }
+    Get-Item -Path $NinjaExecutablePath
+}

--- a/Tests/BuildTargetsCompleter.Tests.ps1
+++ b/Tests/BuildTargetsCompleter.Tests.ps1
@@ -1,0 +1,57 @@
+#Requires -PSEdition Core
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+BeforeAll {
+    . $PSScriptRoot/TestUtilities.ps1
+    . $PSScriptRoot/../Common/CMake.ps1
+    . $PSScriptRoot/../Common/Ninja.ps1
+
+    # Get ninja.exe
+    $NinjaCommand = Get-Command 'ninja.exe' -ErrorAction SilentlyContinue
+    $NinjaPath = if ($NinjaCommand) {
+        $NinjaCommand.Source
+    } else {
+        $BuildToolsPath = Join-Path -Path $PSScriptRoot -ChildPath 'ReferenceBuild/__tools'
+        $Ninja = Download-Ninja (New-Item -Path $BuildToolsPath -ItemType Directory -Force).FullName
+        $Ninja.FullName
+    }
+
+    # Find VS
+    $VSWhere = "${env:ProgramFiles(x86)}/Microsoft Visual Studio/Installer/vswhere.exe"
+    $InstallationPath = & $VSWhere -nologo -latest -property installationPath
+    $MSVCDirectory = Get-ChildItem "$InstallationPath/VC/Tools/MSVC" |
+        Sort-Object -Property Name -Descending |
+        Select-Object -First 1
+
+    # Write the CMake query files
+    $BinaryDirectory = New-Item -Path "$PSScriptRoot/ReferenceBuild/__output/windows-x64" -ItemType Directory -Force
+
+    Enable-CMakeBuildQuery $BinaryDirectory
+
+    # Run CMake
+    $CMake = "$env:ProgramFiles/CMake/bin/cmake.exe"
+    $BuildPath = "$PSScriptRoot/ReferenceBuild".Replace('\', '/')
+    $CMAKE_CXX_COMPILER = (Join-Path -Path $MSVCDirectory -ChildPath "bin/Hostx64/x64/cl.exe").Replace('\', '/')
+    $CMAKE_MAKE_PROGRAM = $NinjaPath.Replace('\', '/')
+    & $CMake --preset windows-x64 `
+        -S $BuildPath `
+        "-DCMAKE_CXX_COMPILER=$CMAKE_CXX_COMPILER" `
+        "-DCMAKE_MAKE_PROGRAM=$CMAKE_MAKE_PROGRAM"
+
+    Import-Module -Force $PSScriptRoot/../PSCMake.psd1 -DisableNameChecking
+}
+
+Describe 'BuildTargetsCompleter' {
+    It 'Returns the targets of the default preset, default configuration when neither is specified' {
+        Stash-Location "$PSScriptRoot/ReferenceBuild" {
+            $Completions = Get-CommandCompletions "Build-CMakeBuild -Targets "
+
+            $Completions.CompletionMatches.Count | Should -Be 3
+            $Completions.CompletionMatches[0].CompletionText | Should -Be 'A_Library'
+            $Completions.CompletionMatches[1].CompletionText | Should -Be 'B_Library'
+            $Completions.CompletionMatches[2].CompletionText | Should -Be 'C_Library'
+        }
+    }
+}

--- a/Tests/ReferenceBuild/CMakeLists.txt
+++ b/Tests/ReferenceBuild/CMakeLists.txt
@@ -1,0 +1,18 @@
+#----------------------------------------------------------------------------------------------------------------------
+#
+#----------------------------------------------------------------------------------------------------------------------
+cmake_minimum_required(VERSION 3.20)
+
+project(ReferenceBuild LANGUAGES CXX)
+
+add_library(A_Library STATIC
+    Reference.cpp
+)
+
+add_library(B_Library
+    Reference.cpp
+)
+
+add_library(C_Library
+    Reference.cpp
+)

--- a/Tests/ReferenceBuild/CMakePresets.json
+++ b/Tests/ReferenceBuild/CMakePresets.json
@@ -1,0 +1,66 @@
+{
+  "version": 3,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 21,
+    "patch": 0
+  },
+  "configurePresets": [{
+      "name": "ninja",
+      "hidden": true,
+      "generator": "Ninja Multi-Config"
+    },
+    {
+      "name": "windows",
+      "inherits": "ninja",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_CXX_COMPILER_FORCED": "true"
+      }
+    },
+    {
+      "name": "windows-x64",
+      "inherits": "windows",
+      "description": "windows-x64",
+      "displayName": "windows-x64",
+      "binaryDir": "${sourceDir}/__output/${presetName}",
+      "cacheVariables": {
+        "CMAKE_SYSTEM_PROCESSOR": "x64",
+        "CMAKE_SYSTEM_VERSION": "10.0.19041.0"
+      },
+      "environment": {}
+    },
+    {
+      "name": "windows-arm",
+      "inherits": "windows",
+      "description": "windows-arm",
+      "displayName": "windows-arm",
+      "binaryDir": "${sourceDir}/__output/${presetName}",
+      "cacheVariables": {
+        "CMAKE_SYSTEM_PROCESSOR": "arm",
+        "CMAKE_SYSTEM_VERSION": "10.0.19041.0"
+      },
+      "environment": {}
+    }
+  ],
+  "buildPresets": [{
+      "name": "windows-x64",
+      "configurePreset": "windows-x64"
+    },
+    {
+      "name": "windows-arm",
+      "configurePreset": "windows-arm"
+    }
+  ],
+  "testPresets": [{
+    "name": "windows-x64",
+    "configurePreset": "windows-x64",
+    "output": {
+      "outputOnFailure": true
+    },
+    "execution": {
+      "noTestsAction": "error",
+      "stopOnFailure": true
+    }
+  }]
+}


### PR DESCRIPTION
`BuildTargetsCompleter` fails when a `-Presets` and `-Configurations` aren't specified, preventing `Build-CMakeBuild -Target <tab>` which is a useful scenario. The fix is small - the changes to `PSCMake.psm1` - but the PR is big - it includes a test for the scenario. The test needs a CMake 'code model' to work with, so this change adds a minimal CMake build which is configured during the test setup for the test.  