### PR TITLE
PSCMake should build/configure from a folder below CMakePresets.json file

### DIFF
--- a/Common/CMake.ps1
+++ b/Common/CMake.ps1
@@ -28,21 +28,27 @@ $ErrorActionPreference = 'Stop'
 
 . $PSScriptRoot/Common.ps1
 
-$script:PreviousLocation = $null
+$PreviousLocation = $null
+$CMakeCandidates = @(
+    (Get-Command 'cmake' -ErrorAction SilentlyContinue)
+    if ($IsWindows) {
+        (Join-Path -Path $env:ProgramFiles -ChildPath 'CMake/bin/cmake.exe')
+    }
+)
 
 <#
  .Synopsis
-  Finds a 'CMakePresets.json' file in the current folder, or an ancestral folder.
+  Finds the root of the CMake build - the current or ancestral folder containing a 'CMakePresets.json' file.
 #>
-function FindPresetsPath {
-    $CurrentPath = (Get-Location).Path
-    while ($CurrentPath.Length -ne 0) {
-        $CandidatePath = Join-Path -Path $CurrentPath -ChildPath 'CMakePresets.json'
-        if (Test-Path -PathType Leaf -Path $CandidatePath) {
-            return $CandidatePath
-        }
-        $CurrentPath = Split-Path $CurrentPath
+function FindCMakeRoot {
+    $CurrentLocation = (Get-Location).Path
+    if ($CurrentLocation -ne $script:PreviousLocation) {
+        Write-Verbose "PreviousLocation = $script:PreviousLocation"
+        Write-Verbose "CurrentLocation = $CurrentLocation"
+        $script:PreviousLocation = $CurrentLocation
+        $script:CMakeRoot = GetPathOfFileAbove $CurrentLocation 'CMakePresets.json'
     }
+    $script:CMakeRoot
 }
 
 <#
@@ -53,24 +59,16 @@ function GetCMakePresets {
     param(
         [switch] $Silent
     )
-    $CurrentLocation = (Get-Location).Path
-    if ($CurrentLocation -ne $script:PreviousLocation) {
-        Write-Verbose "PreviousLocation = $script:PreviousLocation"
-        Write-Verbose "CurrentLocation = $CurrentLocation"
-
-        $script:PreviousLocation = $CurrentLocation
-        $script:CMakePresetsPath = FindPresetsPath
-        if (-not $script:CMakePresetsPath) {
-            if ($Silent) {
-                $script:CMakePresetsJson = $null
-                return $script:CMakePresetsJson
-            }
-            Write-Error "Can't find CMakePresets.json"
+    $CMakeRoot = FindCMakeRoot
+    if (-not $CMakeRoot) {
+        if ($Silent) {
+            return $null
         }
-        Write-Verbose "Presets = $script:CMakePresetsPath"
-        $script:CMakePresetsJson = Get-Content $script:CMakePresetsPath | ConvertFrom-Json
+        Write-Error "Can't find CMakePresets.json"
     }
-    $script:CMakePresetsJson
+    $script:CMakePresetsPath = Join-Path -Path $CMakeRoot -ChildPath 'CMakePresets.json'
+    Write-Verbose "Presets = $CMakePresetsPath"
+    Get-Content $CMakePresetsPath | ConvertFrom-Json
 }
 
 <#
@@ -110,12 +108,6 @@ function GetConfigurePresetNames {
 function GetCMake {
     $CMake = Get-Variable -Name 'CMake' -ValueOnly -Scope global -ErrorAction SilentlyContinue
     if (-not $CMake) {
-        $CMakeCandidates = @(
-            (Get-Command 'cmake' -ErrorAction SilentlyContinue)
-            if ($IsWindows) {
-                (Join-Path -Path $env:ProgramFiles -ChildPath 'CMake/bin/cmake.exe')
-            }
-        )
         foreach ($CMakeCandidate in $CMakeCandidates) {
             $CMake = Get-Command $CMakeCandidate -ErrorAction SilentlyContinue
             if ($CMake) {

--- a/Common/CMake.ps1
+++ b/Common/CMake.ps1
@@ -131,7 +131,7 @@ function GetCMake {
 }
 
 function ResolvePresets {
-    param (
+    param(
         $CMakePresetsJson,
 
         [ValidateSet('buildPresets', 'testPresets')]
@@ -198,7 +198,7 @@ function GetBinaryDirectory {
 
 function Enable-CMakeBuildQuery {
     [CmdletBinding()]
-    param (
+    param(
         [string] $BinaryDirectory,
 
         [ValidateSet('codemodel-v2', 'cache-v2', 'cmakeFiles-v1', 'toolchains-v1')]
@@ -214,14 +214,14 @@ function Enable-CMakeBuildQuery {
 }
 
 function Get-CMakeBuildCodeModelDirectory {
-    param (
+    param(
         [string] $BinaryDirectory
     )
     Join-Path -Path $BinaryDirectory -ChildPath '.cmake/api/v1/reply'
 }
 
 function Get-CMakeBuildCodeModel {
-    param (
+    param(
         [string] $BinaryDirectory
     )
     Get-ChildItem -Path (Get-CMakeBuildCodeModelDirectory $BinaryDirectory) -File -Filter 'codemodel-v2-*' |

--- a/Common/Common.ps1
+++ b/Common/Common.ps1
@@ -27,7 +27,7 @@ Set-StrictMode -Version Latest
 
 function Get-MemberValue {
     [CmdletBinding()]
-    param (
+    param(
         $InputObject,
         $Name,
         $Or = $null

--- a/Common/Common.ps1
+++ b/Common/Common.ps1
@@ -93,3 +93,16 @@ function Touch($Item) {
 function DownloadFile([string] $Url, [string] $DownloadPath) {
     [System.Net.WebClient]::new().DownloadFile($Url, $DownloadPath)
 }
+
+<#
+ .Synopsis
+  Searches the given location and parent folders looking for the given file.
+#>
+function GetPathOfFileAbove([string]$Location, [string]$File) {
+    for (; $Location.Length -ne 0; $Location = Split-Path $Location) {
+        if (Test-Path -PathType Leaf -Path (Join-Path -Path $Location -ChildPath $File)) {
+            $Location
+            break
+        }
+    }
+}

--- a/Common/Common.ps1
+++ b/Common/Common.ps1
@@ -76,7 +76,7 @@ function IsUpToDate($Target) {
     $true
 }
 
-function Stash-Location($Location, $Scriptlet) {
+function Using-Location($Location, $Scriptlet) {
     Push-Location -Path $Location
     try {
         & $Scriptlet

--- a/PSCMake.psm1
+++ b/PSCMake.psm1
@@ -133,7 +133,7 @@ function ConfigurePresetsCompleter {
 #>
 function Configure-CMakeBuild {
     [CmdletBinding()]
-    param (
+    param(
         [Parameter()]
         [string[]] $Presets
     )
@@ -202,7 +202,7 @@ function Configure-CMakeBuild {
 #>
 function Build-CMakeBuild {
     [CmdletBinding()]
-    param (
+    param(
         [Parameter(Position = 0)]
         [string[]] $Presets,
 
@@ -264,7 +264,7 @@ function Build-CMakeBuild {
 }
 
 function Write-CMakeBuild {
-    param (
+    param(
         [Parameter(Position = 0)]
         [string] $Preset,
 

--- a/PSCMake.psm1
+++ b/PSCMake.psm1
@@ -207,7 +207,7 @@ function Build-CMakeBuild {
         [string[]] $Presets,
 
         [Parameter(Position = 1)]
-        [string[]] $Configurations,
+        [string[]] $Configurations = @($null),
 
         [Parameter(Position = 2)]
         [string[]] $Targets,
@@ -253,20 +253,11 @@ function Build-CMakeBuild {
 
         Write-Verbose "CMake Arguments: $CMakeArguments"
 
-        if (-not $Configurations) {
+        foreach ($Configuration in $Configurations) {
             $StartTime = [datetime]::Now
-            & $CMake @CMakeArguments
+            & $CMake @CMakeArguments (($Configuration)?('--config', $Configuration):$null)
             if ($Report) {
                 Report-NinjaBuild (Join-Path $BinaryDirectory '.ninja_log') $StartTime
-            }
-        }
-        else {
-            foreach ($Configuration in $Configurations) {
-                $StartTime = [datetime]::Now
-                & $CMake @CMakeArguments '--config' $Configuration
-                if ($Report) {
-                    Report-NinjaBuild (Join-Path $BinaryDirectory '.ninja_log') $StartTime
-                }
             }
         }
     }

--- a/Tests/BuildTargetsCompleter.Tests.ps1
+++ b/Tests/BuildTargetsCompleter.Tests.ps1
@@ -45,7 +45,7 @@ BeforeAll {
 
 Describe 'BuildTargetsCompleter' {
     It 'Returns the targets of the default preset, default configuration when neither is specified' {
-        Stash-Location "$PSScriptRoot/ReferenceBuild" {
+        Using-Location "$PSScriptRoot/ReferenceBuild" {
             $Completions = Get-CommandCompletions "Build-CMakeBuild -Targets "
 
             $Completions.CompletionMatches.Count | Should -Be 3


### PR DESCRIPTION
PSCMake's `Build-CMakeBuild` and `Configure-CMakeBuild` both invoke `cmake` specifying a preset from a discovered `CMakePresets.json` - discovered by searching the parent folders for the file. But `cmake` *doesn't* search the parent folders, it expects the `CMakePresets.json` to be present in the current folder, so if `Build-` or `Configure-CMakeBuild` are run from a subfolder, the `cmake` invocation fails. For the `cmake` invocation to succeed, the `Build-` and `Configure-CMakeBuild` cmdlets should move to the folder containing the `CMakePresets.json` before invoking it.