### PR TITLE
Add implicit targets if the build is 'scoped'

### DIFF
--- a/PSCMake/PSCMake.psm1
+++ b/PSCMake/PSCMake.psm1
@@ -148,7 +148,7 @@ function Configure-CMakeBuild {
     $CMake = GetCMake
     Using-Location $CMakeRoot {
         foreach ($Preset in $Presets) {
-            Write-Output "Preset: $Preset"
+            Write-Output "Preset         : $Presets"
 
             $ConfigurePreset = $CMakePresetsJson.configurePresets | Where-Object { $_.name -eq $Preset }
             if (-not $ConfigurePreset) {
@@ -230,9 +230,14 @@ function Build-CMakeBuild {
             Write-Error "No Presets values specified, and one could not be inferred."
         }
         $Presets = $PresetNames | Select-Object -First 1
-        Write-Information "No preset specified, defaulting to: $Presets"
     }
 
+    # If;
+    #   * no targets were specified, and
+    #   * the current location is different from the cmake root
+    # Then we're a scoped build!
+    $ScopedBuild = (-not $Targets) -and ($CMakeRoot -ne ((Get-Location).Path))
+    $ScopeLocation = (Get-Location).Path
     $CMake = GetCMake
     Using-Location $CMakeRoot {
         foreach ($Preset in $Presets) {
@@ -246,6 +251,27 @@ function Build-CMakeBuild {
             if ((-not (Test-Path -Path $CMakeCacheFile -PathType Leaf)) -or
                 $Configure) {
                 Configure-CMakeBuild -Presets $ConfigurePreset.name
+            } else {
+                Write-Output "Preset         : $Presets"
+            }
+
+            if ($ScopedBuild) {
+                $CodeModel = Get-CMakeBuildCodeModel $BinaryDirectory
+                $CodeModelConfiguration = $CodeModel.configurations |
+                    Where-Object { $_.name -eq 'Release' }
+                $TargetTuples = $CodeModelConfiguration.targets |
+                    ForEach-Object {
+                        [pscustomobject]@{
+                            Name=$_.name
+                            Folder=$CodeModelConfiguration.directories[$_.directoryIndex].build
+                        }
+                    } |
+                    Where-Object { $_.Folder -ne '.' } |
+                    Where-Object { (Join-Path -Path $CMakeRoot -ChildPath $_.Folder).StartsWith($ScopeLocation) }
+                if ($TargetTuples) {
+                    $Targets = $TargetTuples.Name
+                    Write-Output "Scoped Targets : $Targets"
+                }
             }
 
             $CMakeArguments = @(
@@ -259,6 +285,8 @@ function Build-CMakeBuild {
             Write-Verbose "CMake Arguments: $CMakeArguments"
 
             foreach ($Configuration in $Configurations) {
+                Write-Output "Configuration  : $Configuration"
+
                 $StartTime = [datetime]::Now
                 & $CMake @CMakeArguments (($Configuration)?('--config', $Configuration):$null)
                 if ($Report) {


### PR DESCRIPTION
With #11 merged, `Build-CMakeBuild` can be run from a sub-folder within a `CMakePresets.json`-defined scope. This PR leverages that to add implicit target scoping. If `Build-CMakeBuild` is being run from a sub-folder, and no targets are specified, then the CMake code object-model is loaded to discover targets that are declared in the current folder and lower, and if it finds any it adds them to the targets for the build. The goal is to implicitly scope the build - to build less, more relevant code - based on the context of the shell.

Notes:
* Not all CMake build structures would be amenable - you don't have to nest targets into subfolders, you can define all targets in the root, for example. Those builds wouldn't be affected, or 'benefit' from this. 
* There's not an easy way to opt-out at the point of the `Build-CMakeBuild` command. The closest would be to run `Build-CMakeBuild -Target all`. But in CMake, building 'all' isn't the same as building without a specified target. Perhaps `Build-CMakeBuild` needs a sentinel value for 'no target' - like `*`..?
* There's no, say, 'user-scoped' way to configure the opinions of PSCMake. Perhaps implicit scoping would motivate figuring a way to opt-out...?