### PR TITLE
Teach ci.yaml about 'develop', 'feature/*', 'release/*', 'support/*' branches

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,11 @@ name: PSCMake CI
 on:
   push:
     branches:
+      - develop
+      - feature/*
       - main
+      - release/*
+      - support/*
     paths-ignore:
       - '.vscode/**'
       - 'README.md'


### PR DESCRIPTION
In anticipation of pushing to PowerShell Gallery on `main` CI builds, adding `develop`, `feature/*`, `release/*` and `support/*` branches to accommodate Git Flow style branching.