### PR TITLE
Upload code coverage data to https://codecov.io/

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,6 +28,15 @@ jobs:
             }
             CodeCoverage = @{
               Enabled = $true
+              OutputFormat = 'JaCoCo'
+              OutputPath = '${{ env.GITHUB_WORKSPACE }}/Pester-Coverage.xml'
             }
           }
           Invoke-Pester -Configuration $Configuration
+      - uses: codecov/codecov-action@v2
+        with:
+          files: '${{ env.GITHUB_WORKSPACE }}/Pester-Coverage.xml'
+          flags: unittests
+          name: codecov-umbrella
+          fail_ci_if_error: true
+          verbose: true

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -20,7 +20,9 @@ jobs:
               Passthru = $true
             }
             CodeCoverage = @{
-              Enabled = $false
+              Enabled = $true
+              OutputFormat = 'JaCoCo'
+              OutputPath = '${{ env.GITHUB_WORKSPACE }}/Pester-Coverage.xml'
             }
           }
           Invoke-Pester -Configuration $Configuration

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ CMake file API, the module is able to offer tab-completion when specifying targe
 
 [![build status](https://github.com/MarkSchofield/PSCMake/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/MarkSchofield/PSCMake/actions/workflows/ci.yaml?query=branch%3Amain)
 
+[![codecov](https://codecov.io/gh/MarkSchofield/PSCMake/branch/develop/graph/badge.svg?token=DS41WQROME)](https://codecov.io/gh/MarkSchofield/PSCMake)
+
 ## Installation
 
 To install the module, use PowerShell's `Import-Module` CmdLet:


### PR DESCRIPTION
Leverage https://codecov.io/ for code coverage reporting - adding an extra step to the `ci.yaml` is pretty much all it needs. 