### PR TITLE
Fixes to unblock PSCMake on Linux

### DIFF
--- a/PSCMake/Common/CMake.ps1
+++ b/PSCMake/Common/CMake.ps1
@@ -197,7 +197,7 @@ function Enable-CMakeBuildQuery {
         [string[]] $ObjectKinds = @('codemodel-v2', 'cache-v2', 'cmakeFiles-v1', 'toolchains-v1')
     )
     $CMakeQueryApiDirectory = Join-Path -Path $BinaryDirectory -ChildPath '.cmake/api/v1/query'
-    $null = mkdir $CMakeQueryApiDirectory -ErrorAction SilentlyContinue
+    $null = New-Item -ItemType Directory -Path $CMakeQueryApiDirectory -Force -ErrorAction SilentlyContinue
     $ObjectKinds |
         ForEach-Object {
             $QueryFile = Join-Path -Path $CMakeQueryApiDirectory -ChildPath $_

--- a/PSCMake/Common/Console.ps1
+++ b/PSCMake/Common/Console.ps1
@@ -61,7 +61,7 @@ public static SafeFileHandle GetConOut()
 '@
 
 $script:Console = $null
-$script:IsVirtualTerminalProcessingEnabled = $null
+$script:IsVirtualTerminalProcessingEnabled = if ($IsWindows) { $null } else { $true }
 
 function GetConsole {
     if (-not $script:Console) {


### PR DESCRIPTION
A couple of small fixes to Linux execution;
1. Use `New-Item -ItemType Directory` to make directories - it works on all platforms. `mkdir` has different options on different platforms.
2. `PSCMake/Common/Console.ps1` defaults `$script:IsVirtualTerminalProcessingEnabled` to `$null` to force evaluation as to whether Windows VT processing is available. Since non-Windows platforms generally support VT processing, default to `$true` for non-Windows.