### PR TITLE
'ci.yaml' should publish to PowerShell Gallery

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Invoke-Pester
         shell: pwsh
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ on:
       - 'README.md'
   workflow_dispatch:
 jobs:
-  run-pester-tests:
+  build:
     runs-on: windows-latest
     steps:
       - name: Checkout
@@ -40,3 +40,29 @@ jobs:
           name: codecov-umbrella
           fail_ci_if_error: true
           verbose: true
+      - name: Build
+        shell: pwsh
+        run: |
+          & .\Build\Publish.ps1 -Verbose
+      - name: Upload __packages
+        uses: actions/upload-artifact@v2
+        with:
+          name: __packages
+          path: __packages
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: PowerShellGallery
+    steps:
+      - name: Download __packages
+        id: download
+        uses: actions/download-artifact@v3
+        with:
+          name: __packages
+          path: __packages
+      - name: Publish to PowerShellGallery
+        shell: pwsh
+        run: |
+          $ModulePath = Join-Path -Path '${{steps.download.outputs.download-path}}' -ChildPath 'PSCMake'
+          Publish-Module -Path $ModulePath -NuGetApiKey '${{ secrets.PSCMAKEPUBLISH }}' -Repository PSGallery

--- a/Build/Publish.ps1
+++ b/Build/Publish.ps1
@@ -50,14 +50,11 @@ PrereleaseMetadata  = $PrereleaseMetadata
 
 Update-ModuleManifest -Path (Join-Path -Path $PSScriptRoot -ChildPath '../PSCMake/PSCMake.psd1') -ModuleVersion $BaseVersion -Prerelease $PrereleaseMetadata
 
-$PSRepositoryName = Split-Path -Leaf $RepositoryRoot
+$SourceModulePath = Resolve-Path "$RepositoryRoot/PSCMake"
+
 $PSRepositoryPath = Join-Path -Path $RepositoryRoot -ChildPath '__packages'
+$PSRepositoryModulePath = Join-Path -Path $PSRepositoryPath -ChildPath "PSCMake"
 
-$Null = Unregister-PSRepository -Name $PSRepositoryName -ErrorAction SilentlyContinue
 $Null = New-Item -Path $PSRepositoryPath -ItemType Directory -Force
-$Null = Remove-Item -Path "$PSRepositoryPath/PSCMake.$BaseVersion$PrereleaseMetadata.nupkg" -Force -ErrorAction SilentlyContinue
-$Null = Register-PSRepository -Name $PSRepositoryName -SourceLocation $PSRepositoryPath -PublishLocation $PSRepositoryPath
-
-$ModulePath = Resolve-Path "$RepositoryRoot/PSCMake"
-
-Publish-Module -Repository $PSRepositoryName -Path $ModulePath -Force
+$Null = Remove-Item -Path $PSRepositoryModulePath -Force -Recurse -ErrorAction SilentlyContinue
+$Null = Copy-Item -Path $SourceModulePath -Destination $PSRepositoryModulePath -Recurse -Force


### PR DESCRIPTION
The CI build will now publish to PowerShell Gallery. The changes:
*  `Build/Publish.ps1` is reworked to _copy_ the PSCMake module into the `__packages` folder - as opposed to making a NuGet, which was hard to consume.
* The `ci.yaml` adds a `release` job that runs in the `PowerShellGallery` environment. The job downloads the `__packages` artifact from the `build` job and publishes to the `PSGallery` PSRepository.