### PR TITLE
Requery 'scoped targets' with the correct configuration

### DIFF
--- a/PSCMake/Common/CMake.ps1
+++ b/PSCMake/Common/CMake.ps1
@@ -408,6 +408,29 @@ function Get-CMakeBuildCodeModel {
         ConvertFrom-Json
 }
 
+function GetScopedTargets {
+    param(
+        $CodeModel,
+        $Configuration,
+        $ScopeLocation
+    )
+    $CodeModelConfiguration = if ($Configuration) {
+        $CodeModel.configurations | Where-Object { $_.name -eq $Configuration }
+    } else {
+        $CodeModel.configurations[0]
+    }
+    $CodeModelConfiguration.targets |
+        Where-Object {
+            $Folder = $CodeModelConfiguration.directories[$_.directoryIndex].build
+            $Folder = if ($Folder -eq '.') {
+                $CMakeRoot
+            } else {
+                Join-Path -Path $CMakeRoot -ChildPath $Folder
+            }
+            $Folder.StartsWith($ScopeLocation)
+        }
+}
+
 function WriteDot {
     param (
         $Configuration,


### PR DESCRIPTION
In order to implicitly scope builds, `Build-CMakeBuild` needs to find the targets defined in the current folder or lower. The current implementation is hard-coded to find targets in the 'Release' configuration, so if the build contains 'Debug'-only targets, then 'Debug' builds might miss targets, or 'Release' builds might over-specify targets. This PR defers the resolution of the scoped targets until a Configuration has been identified, so that the correct targets can be used.