### PR TITLE
Add 'Invoke-CMakeOutput' for running the output of a CMake build

### DIFF
--- a/PSCMake/Common/CMake.ps1
+++ b/PSCMake/Common/CMake.ps1
@@ -398,16 +398,54 @@ function Get-CMakeBuildCodeModelDirectory {
     Join-Path -Path $BinaryDirectory -ChildPath '.cmake/api/v1/reply'
 }
 
+<#
+ .Synopsis
+  Gets PowerShell representation of the CodeModel JSON for the given binary directory.
+
+ .Outputs
+  The PowerShell representation of the CodeModel JSON for the given binary directory, or `$null` if it can't be found.
+#>
 function Get-CMakeBuildCodeModel {
     param(
         [string] $BinaryDirectory
     )
-    Get-ChildItem -Path (Get-CMakeBuildCodeModelDirectory $BinaryDirectory) -File -Filter 'codemodel-v2-*' |
+    Get-ChildItem -Path (Get-CMakeBuildCodeModelDirectory $BinaryDirectory) -File -Filter 'codemodel-v2-*' -ErrorAction SilentlyContinue |
         Select-Object -First 1 |
         Get-Content |
         ConvertFrom-Json
 }
 
+<#
+ .Synopsis
+  Gets the target with the given name, for the given configuration from the specified code model.
+
+ .Outputs
+  The PowerShell representation of the target from the CodeModel JSON.
+#>
+function GetNamedTarget {
+    param(
+        $CodeModel,
+        $Configuration,
+        $Name
+    )
+    $CodeModelConfiguration = if ($Configuration) {
+        $CodeModel.configurations | Where-Object { $_.name -eq $Configuration }
+    } else {
+        $CodeModel.configurations[0]
+    }
+    $CodeModelConfiguration.targets |
+        Where-Object {
+            $_.name -eq $Name
+        }
+}
+
+<#
+ .Synopsis
+  Gets all targets within the given folder scope, for the given configuration from the specified code model.
+
+ .Outputs
+  The PowerShell representation of the target(s) from the CodeModel JSON.
+#>
 function GetScopedTargets {
     param(
         $CodeModel,

--- a/PSCMake/PSCMake.psd1
+++ b/PSCMake/PSCMake.psd1
@@ -69,7 +69,7 @@ PowerShellVersion = '7.0'
 # NestedModules = @()
 
 # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
-FunctionsToExport = 'Build-CMakeBuild', 'Configure-CMakeBuild', 'Write-CMakeBuild'
+FunctionsToExport = 'Build-CMakeBuild', 'Configure-CMakeBuild', 'Write-CMakeBuild', 'Invoke-CMakeOutput'
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
 CmdletsToExport = @()

--- a/README.md
+++ b/README.md
@@ -5,8 +5,13 @@ provide a declaration - through a JSON file - of the available builds, where the
 sorts of useful metadata that makes it easier to build standard tooling around the build. This PowerShell module is one
 attempt at such tooling.
 
-At the minute the PowerShell module simply surfaces the ability to configure and build using CMake. By leveraging the
-CMake file API, the module is able to offer tab-completion when specifying targets to build.
+The PSCMake PowerShell module supports;
+
+    1. configuring and building a CMake build,
+    2. generating a 'DGML'- or 'DOT'- file for a build,
+    3. invoking executable CMake build outputs.
+
+By leveraging the CMake file API, the module is able to offer tab-completion for presets, configurations and targets, and can implicitly scope the build based on the current working directory.
 
 [![build status](https://github.com/MarkSchofield/PSCMake/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/MarkSchofield/PSCMake/actions/workflows/ci.yaml?query=branch%3Amain)
 
@@ -17,7 +22,7 @@ CMake file API, the module is able to offer tab-completion when specifying targe
 To install the module, use PowerShell's `Import-Module` CmdLet:
 
 ```powershell
-> Import-Module PSCMake.psd1
+> Import-Module PSCMake
 ```
 
 Note: The module uses unapproved PowerShell verbs, preferring CMake verbs. As a result, the Import-Module will report
@@ -30,6 +35,7 @@ The module provides the following commands:
 1. `Configure-CMakeBuild` - To run CMake configuration for a given preset
 2. `Build-CMakeBuild` - To run a CMake build.
 3. `Write-CMakeBuild` - To output the CMake build as a DOT or DGML graph.
+4. `Invoke-CMakeOutput` - To run an executable output from a CMake build, by target name or implicitly by scope.
 
 Running `Build-CMakeBuild` by itself would run the first `buildConfiguration`. Run either command with `-?` to get more
 details.


### PR DESCRIPTION
This PR adds 'Invoke-CMakeOutput' as an exported Cmdlet of the PSCMake PowerShell Module. 'Invoke-CMakeOutput' uses either specified preset/configuration/target values or implicit scoping to find an executable target and run it.