### PR TITLE
Build-CMakeBuild should configure the CMake build if the code-model directory doesn't exist

### DIFF
--- a/PSCMake/PSCMake.psm1
+++ b/PSCMake/PSCMake.psm1
@@ -278,12 +278,14 @@ function Build-CMakeBuild {
             $CMakeCacheFile = Join-Path -Path $BinaryDirectory -ChildPath 'CMakeCache.txt'
 
             # Run CMake configure if;
-            #  1) "$BinaryDirectory/CMakeCache.txt" doesn't exist
-            #  2) '-configure' was specified
-            #  3) '-fresh' was specified
-            if ((-not (Test-Path -Path $CMakeCacheFile -PathType Leaf)) -or
-                $Configure -or
-                $Fresh) {
+            #  1) '-configure' was specified
+            #  2) '-fresh' was specified
+            #  3) "$BinaryDirectory/CMakeCache.txt" doesn't exist
+            #  4) The "Get-CMakeBuildCodeModelDirectory" folder doesn't exist
+            if ($Configure -or
+                $Fresh -or
+                (-not (Test-Path -Path $CMakeCacheFile -PathType Leaf)) -or
+                (-not (Test-Path -Path (Get-CMakeBuildCodeModelDirectory $BinaryDirectory) -PathType Container))) {
                 ConfigureCMake $CMake $CMakePresetsJson $ConfigurePreset -Fresh:$Fresh
             }
 


### PR DESCRIPTION
As per #38, `Build-CMakeBuild` checking for the existence of the `CMakeCache.txt` file isn't really sufficient to know if CMake configuration succeeded:

> With a completely empty `CMAKE_BINARY_DIR`, running `Build-CMakeBuild` will cause CMake configuration to run since `Build-CMakeBuild` looks for the `CMakeCache.txt` as a heuristic to identify whether CMake configuration has already run. If configuration **_fails_**, then an incomplete `CMakeCache.txt` is written, but no build file has been written, so a subsequent `Build-CMakeBuild` will fail differently: `CMakeCache.txt` exists, so `Build-CMakeBuild` doesn't run CMake configuration, and instead attempts to run the build and the build will fail, complaining of missing files. `Build-CMakeBuild` failing differently, makes the root cause of the problem - CMake configuration failing - harder to identify.
> 
> If `Build-CMakeBuild` were also to check for the existence of the CMake File-API folder - which is written much later in the CMake configuration process - then it is more likely that CMake configuration was successful. If CMake configuration wasn't successful, then `Build-CMakeBuild` would re-run it, and the `Build-CMakeBuild` would be consistent.

This PR changes `Build-CMakeBuild` to check for the existence of the CMake File-API result folder as a heuristic to identify whether CMake configuration was successful, re-running CMake configuration if it wasn't.