### PR TITLE
Report errors from Build-CMakeBuild and Configure-CMakeBuild if the invoked CMake command-line fails

### DIFF
--- a/PSCMake/Common/Common.ps1
+++ b/PSCMake/Common/Common.ps1
@@ -80,7 +80,7 @@ function IsUpToDate($Target) {
 function Using-Location($Location, $Scriptlet) {
     Push-Location -Path $Location
     try {
-        & $Scriptlet
+        Invoke-Command $Scriptlet
     } finally {
         Pop-Location
     }

--- a/PSCMake/PSCMake.psm1
+++ b/PSCMake/PSCMake.psm1
@@ -145,6 +145,9 @@ function ConfigureCMake {
     Write-Verbose "CMake Arguments: $CMakeArguments"
 
     & $CMake @CMakeArguments
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "Configuration failed. Command line: '$($CMake.Source)' $($CMakeArguments -join ' ')"
+    }
 }
 
 <#

--- a/PSCMake/PSCMake.psm1
+++ b/PSCMake/PSCMake.psm1
@@ -319,6 +319,10 @@ function Build-CMakeBuild {
 
                 $StartTime = [datetime]::Now
                 & $CMake @CMakeArguments (($Configuration)?('--config', $Configuration):$null)
+                if ($LASTEXITCODE -ne 0) {
+                    Write-Error "Build failed. Command line: '$($CMake.Source)' $($CMakeArguments -join ' ')"
+                }
+
                 if ($Report) {
                     Report-NinjaBuild (Join-Path $BinaryDirectory '.ninja_log') $StartTime
                 }

--- a/PSCMake/PSCMake.psm1
+++ b/PSCMake/PSCMake.psm1
@@ -310,10 +310,12 @@ function Build-CMakeBuild {
                 $CMakeArguments = @(
                     '--build'
                     '--preset', $Preset
-                    if ($Targets) {
-                        '--target', $Targets
-                    }
                 )
+
+                if ($Targets) {
+                    $CMakeArguments += '--target'
+                    $CMakeArguments += $Targets
+                }
 
                 Write-Verbose "CMake Arguments: $CMakeArguments"
 


### PR DESCRIPTION
As called out in #37, `Invoke-CMakeOutput` will run `Configure-CMakeBuild` and `Build-CMakeBuild` (as necessary) before attempting to identify and run a built target. If either `Configure-CMakeBuild` or `Build-CMakeBuild` fail, `Invoke-CMakeOutput` will carry on regardless. This means that - in the best case - superfluous errors are written about missing files or - potentially worse - stale binaries are executed. By logging PowerShell errors from `Configure-CMakeBuild` and `Build-CMakeBuild` if the CMake command returns a non-zero exit code, then execution of `Invoke-CMakeOutput` stops.