### PR TITLE
Fix CodeCov upload

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,8 @@ on:
 jobs:
   build:
     runs-on: windows-latest
+    environment:
+      name: General
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -31,15 +33,16 @@ jobs:
             CodeCoverage = @{
               Enabled = $true
               OutputFormat = 'JaCoCo'
-              OutputPath = '${{ env.GITHUB_WORKSPACE }}/Pester-Coverage.xml'
+              OutputPath = '${{ github.workspace }}/Pester-Coverage.xml'
             }
           }
           Invoke-Pester -Configuration $Configuration
       - uses: codecov/codecov-action@v4
         with:
-          files: '${{ env.GITHUB_WORKSPACE }}/Pester-Coverage.xml'
+          files: '${{ github.workspace }}/Pester-Coverage.xml'
           flags: unittests
           name: codecov-umbrella
+          token: '${{ secrets.CODECOV_TOKEN }}'
           fail_ci_if_error: true
           verbose: true
       - name: Build

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -5,6 +5,8 @@ on:
 jobs:
   build:
     runs-on: windows-latest
+    environment:
+      name: General
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -22,7 +24,7 @@ jobs:
             CodeCoverage = @{
               Enabled = $true
               OutputFormat = 'JaCoCo'
-              OutputPath = '${{ env.GITHUB_WORKSPACE }}/Pester-Coverage.xml'
+              OutputPath = '${{ github.workspace }}/Pester-Coverage.xml'
             }
           }
           Invoke-Pester -Configuration $Configuration


### PR DESCRIPTION
There's a couple of fixes needed:
* In moving 'codecov/codecov-action' from 'v3' to 'v4' the upload token became required. I've added a 'General' environment that contains a `CODECOV_TOKEN` secret, and pass that to the 'codecov/codecov-action@v4' action.
* I'm unable to use `${{ env.GITHUB_WORKSPACE }}` to find the workspace location - which is where the code coverage report is generated. It looks like this expected - as per [the documentation](https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables). It must've be a behavior change, or it was working accidentally before - I don't have old logs to see old behavior, so can't validate. Regardless, I can get the workspace location through `${{ github.workspace }}`, so switching to use that.