### PR TITLE
Argument completer for 'Invoke-CMakeOutput -Target' should only include executables

### DIFF
--- a/PSCMake/Common/CMake.ps1
+++ b/PSCMake/Common/CMake.ps1
@@ -391,6 +391,27 @@ function Enable-CMakeBuildQuery {
         }
 }
 
+# For the 'code model' JSON that was found, load the full 'target' JSON to be able to find 'EXECUTABLE' targets.
+#
+function FilterExecutableTargets{
+    param (
+        $CodeModelDirectory,
+        $TargetTuplesCodeModel
+    )
+    $TargetJsons = $TargetTuplesCodeModel |
+        ForEach-Object {
+            Join-Path -Path $CodeModelDirectory -ChildPath $_.jsonFile |
+                Get-Item |
+                Get-Content |
+                ConvertFrom-Json
+        }
+
+    $TargetJsons |
+        Where-Object {
+        $_.type -eq 'EXECUTABLE'
+    }
+}
+
 function Get-CMakeBuildCodeModelDirectory {
     param(
         [string] $BinaryDirectory


### PR DESCRIPTION
This PR changes the argument completer for `Invoke-CMakeOutput`'s `-Target` parameter to only include targets of type "EXECUTABLE". The code already existed in the body of `Invoke-CMakeOutput`, it's just a case of breaking it out and using it from a new `ExecutableTargetsCompleter` method.

The old argument completer just needed to parse the 'code model' JSON, but to get the executable type, it needs to load the target-specific JSON. This is going to be more work, so it might not be worth it - let's check this in and see how it feels. The work can be minimized by filtering the 'code model' JSON by `$WordsToComplete`, so that there's fewer targets to check their type.