### PR TITLE
'FindCMakeRoot' shouldn't attempt to cache the CMake root path

### DIFF
--- a/PSCMake/Common/CMake.ps1
+++ b/PSCMake/Common/CMake.ps1
@@ -30,7 +30,6 @@ $ErrorActionPreference = 'Stop'
 
 $PEnv = Get-ChildItem env: | ToHashTable
 
-$PreviousLocation = $null
 $CMakeCandidates = @(
     (Get-Command 'cmake' -ErrorAction SilentlyContinue)
     if ($IsWindows) {
@@ -44,13 +43,7 @@ $CMakeCandidates = @(
 #>
 function FindCMakeRoot {
     $CurrentLocation = (Get-Location).Path
-    if ($CurrentLocation -ne $script:PreviousLocation) {
-        Write-Verbose "PreviousLocation = $script:PreviousLocation"
-        Write-Verbose "CurrentLocation = $CurrentLocation"
-        $script:PreviousLocation = $CurrentLocation
-        $script:CMakeRoot = GetPathOfFileAbove $CurrentLocation 'CMakePresets.json'
-    }
-    $script:CMakeRoot
+    GetPathOfFileAbove $CurrentLocation 'CMakePresets.json'
 }
 
 $script:CMakePresetsPath = $null
@@ -478,13 +471,14 @@ function GetScopedTargets {
     } else {
         $CodeModel.configurations[0]
     }
+    $SourceDir = $CodeModel.paths.source
     $CodeModelConfiguration.targets |
         Where-Object {
             $Folder = $CodeModelConfiguration.directories[$_.directoryIndex].build
             $Folder = if ($Folder -eq '.') {
-                $CMakeRoot
+                $SourceDir
             } else {
-                Join-Path -Path $CMakeRoot -ChildPath $Folder
+                Join-Path -Path $SourceDir -ChildPath $Folder
             }
             $Folder.StartsWith($ScopeLocation)
         }


### PR DESCRIPTION
Fixes #57.

FindCMakeRoot attempts to cache the CMake root - if the `(Get-Location).Path` hasn't changed between calls, it uses the same path. But if a CMakePresets.json is added/removed/moved between calls, then the cached answer could be wrong, and weirdness ensues. Just removing this premature optimization seems like the right things to do.

`FindCMakeRoot` was also caching the CMakeRoot at a script level, that `GetScopedTargets` was using - causing awkward coupling between the two. Since `GetScopedTargets` is passed the 'code model', and that knows the root, just reading from there removes the coupling.
