### PR TITLE
Format PowerShell code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "powershell.codeFormatting.pipelineIndentationStyle": "IncreaseIndentationForFirstPipeline",
+    "powershell.codeFormatting.newLineAfterCloseBrace": false
+}

--- a/PSCMake/Common/CMake.ps1
+++ b/PSCMake/Common/CMake.ps1
@@ -96,11 +96,11 @@ function GetBuildPresetNames {
         # Filter presets that have configure presets that have conditions that evaluate to $false
         $Presets = $Presets | Where-Object {
             $BuildPresetJson = $_
-            $ConfigurePresetJson = $CMakePresetsJson.configurePresets |
-                Where-Object { $_.name -eq $BuildPresetJson.configurePreset } |
-                Where-Object { EvaluatePresetCondition $_ $CMakePresetsJson.configurePresets }
+            $ConfigurePresetJson = $CMakePresetsJson.configurePresets | Where-Object { $_.name -eq $BuildPresetJson.configurePreset } | Where-Object { EvaluatePresetCondition $_ $CMakePresetsJson.configurePresets }
+
             $null -ne $ConfigurePresetJson
         }
+
         $Presets.name
     }
 }
@@ -218,8 +218,7 @@ function EvaluateCondition {
         $ConditionJson,
         $PresetJson
     )
-    switch ($ConditionJson.type)
-    {
+    switch ($ConditionJson.type) {
         'equals' {
             return (MacroReplacement $ConditionJson.lhs $PresetJson) -eq (MacroReplacement $ConditionJson.rhs $PresetJson)
         }
@@ -302,8 +301,8 @@ function GetMacroConstants {
     }
 
     @{
-        '${hostSystemName}'=$HostSystemName
-        '$vendor{PSCMake}'='true'
+        '${hostSystemName}' = $HostSystemName
+        '$vendor{PSCMake}'  = 'true'
     }
 }
 
@@ -386,7 +385,7 @@ function Enable-CMakeBuildQuery {
 
 # For the 'code model' JSON that was found, load the full 'target' JSON to be able to find 'EXECUTABLE' targets.
 #
-function FilterExecutableTargets{
+function FilterExecutableTargets {
     param (
         $CodeModelDirectory,
         $TargetTuplesCodeModel
@@ -397,12 +396,12 @@ function FilterExecutableTargets{
                 Get-Item |
                 Get-Content |
                 ConvertFrom-Json
-        }
+            }
 
     $TargetJsons |
         Where-Object {
-        $_.type -eq 'EXECUTABLE'
-    }
+            $_.type -eq 'EXECUTABLE'
+        }
 }
 
 function Get-CMakeBuildCodeModelDirectory {

--- a/PSCMake/Common/Common.ps1
+++ b/PSCMake/Common/Common.ps1
@@ -40,7 +40,7 @@ function Get-MemberValue {
  .Synopsis
   Performs linear interpolation from the first color to the second.
 #>
-function ColorInterpolation{
+function ColorInterpolation {
     param(
         [System.Drawing.Color]$FromColor,
         [System.Drawing.Color]$ToColor,

--- a/PSCMake/Common/Console.ps1
+++ b/PSCMake/Common/Console.ps1
@@ -104,7 +104,7 @@ function IsVirtualTerminalProcessingEnabled {
  .Synopsis
   Returns the control codes to set the foreground color to the specified value.
 #>
-function ColorToControlCode{
+function ColorToControlCode {
     param(
         [System.Drawing.Color]$Color
     )
@@ -117,7 +117,7 @@ function ColorToControlCode{
  .Synopsis
   Returns the control codes to reset foreground attributes, if virtual terminal processing is enable.
 #>
-function ResetForegroundControlCode{
+function ResetForegroundControlCode {
     if (IsVirtualTerminalProcessingEnabled) {
         "`e[39m"
     }

--- a/PSCMake/Common/Ninja.ps1
+++ b/PSCMake/Common/Ninja.ps1
@@ -43,18 +43,18 @@ function TryParseNinjaLog {
     )
     if (Test-Path -Path $NinjaLogPath -PathType Leaf) {
         Get-Content $NinjaLogPath |
-            Where-Object {$_[0] -ne '#'} |
+            Where-Object { $_[0] -ne '#' } |
             ForEach-Object {
                 $Tokens = $_ -split "\t"
                 [int]$StartTime = $Tokens[0]
                 [int]$EndTime = $Tokens[1]
                 [pscustomobject]@{
-                    StartTime=$StartTime
-                    EndTime=$EndTime
-                    WriteTime=([long]$Tokens[2])
-                    File=$Tokens[3]
-                    CommandHash=$Tokens[4]
-                    Duration=($EndTime - $StartTime)
+                    StartTime   = $StartTime
+                    EndTime     = $EndTime
+                    WriteTime   = ([long]$Tokens[2])
+                    File        = $Tokens[3]
+                    CommandHash = $Tokens[4]
+                    Duration    = ($EndTime - $StartTime)
                 }
             }
     }
@@ -97,7 +97,7 @@ function Report-NinjaBuild {
     )
     $BuildStartNinjaTime = ConvertTo-NinjaTime $BuildStartTime
     $Entries = (TryParseNinjaLog $NinjaLogPath) |
-        Where-Object {$_.WriteTime -ge $BuildStartNinjaTime}
+        Where-Object { $_.WriteTime -ge $BuildStartNinjaTime }
     $Statistics = $Entries | Measure-Object -Property Duration -Maximum
     if (-not $Statistics) {
         return

--- a/PSCMake/PSCMake.psm1
+++ b/PSCMake/PSCMake.psm1
@@ -194,7 +194,7 @@ function ConfigureCMake {
  .Parameter Presets
   The configure preset names to use.
 
-.Parameter Fresh
+ .Parameter Fresh
   A switch specifying whether a 'fresh' configuration is performed - removing any existing cache.
 
  .Example
@@ -432,7 +432,7 @@ function Write-CMakeBuild {
 
 #>
 function Invoke-CMakeOutput {
-    [CmdletBinding(PositionalBinding=$false)]
+    [CmdletBinding(PositionalBinding = $false)]
     param(
         [Parameter()]
         [string] $Preset,

--- a/Tests/EvaluateCondition.Tests.ps1
+++ b/Tests/EvaluateCondition.Tests.ps1
@@ -4,9 +4,9 @@ BeforeAll {
     . $PSScriptRoot/../PSCMake/Common/CMake.ps1
 
     Mock GetMacroConstants { @{
-        '${hostSystemName}'='Linux'
-        '$vendor{PSCMake}'='true'
-    } }
+            '${hostSystemName}' = 'Linux'
+            '$vendor{PSCMake}'  = 'true'
+        } }
 }
 
 Describe 'EvaluateCondition' {

--- a/Tests/GetConfigurePresetNames.Tests.ps1
+++ b/Tests/GetConfigurePresetNames.Tests.ps1
@@ -4,9 +4,9 @@ BeforeAll {
     . $PSScriptRoot/../PSCMake/Common/CMake.ps1
 
     Mock GetMacroConstants { @{
-        '${hostSystemName}'='Linux'
-        '$vendor{PSCMake}'='true'
-    } }
+            '${hostSystemName}' = 'Linux'
+            '$vendor{PSCMake}'  = 'true'
+        } }
 }
 
 Describe 'GetConfigurePresetNames' {

--- a/Tests/MacroReplacement.Tests.ps1
+++ b/Tests/MacroReplacement.Tests.ps1
@@ -6,9 +6,9 @@ BeforeAll {
     $env:PSCMAKE_ENV_TEST = 43
 
     Mock GetMacroConstants { @{
-        '${hostSystemName}'='Linux'
-        '$vendor{PSCMake}'='true'
-    } }
+            '${hostSystemName}' = 'Linux'
+            '$vendor{PSCMake}'  = 'true'
+        } }
 
     Mock GetCMakePresetsPath {
         'C:\chunky\bacon\CMakePresets.json'

--- a/Tests/Using-Location.Tests.ps1
+++ b/Tests/Using-Location.Tests.ps1
@@ -15,17 +15,21 @@ AfterAll {
 Describe 'Using-Location' {
     It 'Navigates to the given location and back again afterwards.' {
         Set-Location $PSScriptRoot
+
         Using-Location $TestFolder {
             Get-Location |
                 Should -Be $TestFolder
         }
+
         Get-Location |
             Should -Be $PSScriptRoot
     }
     It 'Restores the location when the scriptlet fails.' {
         Set-Location $PSScriptRoot
-        {Using-Location $TestFolder { Write-Error "Oh no!" } } |
+
+        { Using-Location $TestFolder { Write-Error "Oh no!" } } |
             Should -Throw
+
         Get-Location |
             Should -Be $PSScriptRoot
     }

--- a/Tests/Write-CMakeBuild.Tests.ps1
+++ b/Tests/Write-CMakeBuild.Tests.ps1
@@ -26,7 +26,7 @@ digraph CodeModel {
 }
 '@
             ((Write-CMakeBuild) -join '') |
-              Should -Be ($ExpectedDotFile -replace '\r\n','')
+                Should -Be ($ExpectedDotFile -replace '\r\n', '')
         }
     }
 }


### PR DESCRIPTION
This PR adds `:/.vscode/settings.json` with PowerShell code formatting settings and then formats the code. Unfortunately, the `WriteDgml` method loses its indentation when formatted so I manually reverted those changes - it's not clear how to disable formatting of a section of a file. This gets a stake in the ground; would be good to automate this properly.