### PR TITLE
Include CMake standard targets in 'BuildTargetsCompleter'

### DIFF
--- a/PSCMake/PSCMake.psm1
+++ b/PSCMake/PSCMake.psm1
@@ -97,6 +97,20 @@ function BuildTargetsCompleter {
     $ConfigurationsJson = $CMakeCodeModel.configurations |
         Where-Object -Property 'name' -EQ $ConfigurationName
     $TargetNames = $ConfigurationsJson.targets.name
+
+    # Add standard CMake targets 'all', 'clean', 'install'
+    $TargetNames += @(
+        'all'
+        'clean'
+        'install'
+    )
+
+    # Add standard CMake target 'test' if 'CTestTestfile.cmake' exists in the binary directory.
+    $CTestFilePath = Join-Path -Path $BinaryDirectory -ChildPath 'CTestTestfile.cmake'
+    if (Test-Path -Path $CTestFilePath -PathType Leaf -ErrorAction SilentlyContinue) {
+        $TargetNames += 'test'
+    }
+
     $TargetNames |
         Where-Object { $_ -ilike "$WordToComplete*" }
 }

--- a/Tests/BuildTargetsCompleter.Tests.ps1
+++ b/Tests/BuildTargetsCompleter.Tests.ps1
@@ -20,10 +20,13 @@ Describe 'BuildTargetsCompleter' {
         Using-Location "$PSScriptRoot/ReferenceBuild" {
             $Completions = Get-CommandCompletions "Build-CMakeBuild -Targets "
 
-            $Completions.CompletionMatches.Count | Should -Be 3
+            $Completions.CompletionMatches.Count | Should -Be 6
             $Completions.CompletionMatches[0].CompletionText | Should -Be 'A_Library'
             $Completions.CompletionMatches[1].CompletionText | Should -Be 'B_Library'
             $Completions.CompletionMatches[2].CompletionText | Should -Be 'C_Library'
+            $Completions.CompletionMatches[3].CompletionText | Should -Be 'all'
+            $Completions.CompletionMatches[4].CompletionText | Should -Be 'clean'
+            $Completions.CompletionMatches[5].CompletionText | Should -Be 'install'
         }
     }
 }


### PR DESCRIPTION
CMake has standard targets - 'all', 'clean', 'test' and 'install' - that aren't included in the targets returned from 'BuildTargetsCompleter'. 'BuildTargetsCompleter' reads from the cmake-file-api output, which doesn't include the standard targets, so we should just add them to the targets discovered from the cmake-file-api output. And that's what this PR does. The 'all' and 'clean' targets are always present. The 'test' target is available if the 'CTest' module has been included - which also writes 'CTestTestfile.cmake'. So we can check for the existence of 'CTestTestfile.cmake' to see if the 'test' preset should be returned. The 'install' target is only available if 'install' has been called, but it's not clear how to detect if 'install' has been called; so including 'install' always.