### PR TITLE
General cleanup and PSScriptAnalyzer fixes

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Mark Schofield
+Copyright (c) 2025 Mark Schofield
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/PSCMake/Common/CMake.ps1
+++ b/PSCMake/Common/CMake.ps1
@@ -1,7 +1,7 @@
 #----------------------------------------------------------------------------------------------------------------------
 # MIT License
 #
-# Copyright (c) 2021 Mark Schofield
+# Copyright (c) 2025 Mark Schofield
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/PSCMake/Common/CMake.ps1
+++ b/PSCMake/Common/CMake.ps1
@@ -131,12 +131,12 @@ function GetConfigurePresetNames {
     Finds the 'CMake' command.
 #>
 function GetCMake {
-    $CMake = Get-Variable -Name 'CMake' -ValueOnly -Scope global -ErrorAction SilentlyContinue
+    $CMake = Get-Variable -Name 'CMake' -ValueOnly -Scope script -ErrorAction SilentlyContinue
     if (-not $CMake) {
         foreach ($CMakeCandidate in $CMakeCandidates) {
             $CMake = Get-Command $CMakeCandidate -ErrorAction SilentlyContinue
             if ($CMake) {
-                $global:CMake = $CMake
+                $script:CMake = $CMake
                 break
             }
         }
@@ -280,7 +280,7 @@ function GetBinaryDirectory {
         $CMakePresetsJson,
         $ConfigurePreset
     )
-    $BinaryDirectory = ResolvePresetProperty $CMakePresetsJson $ConfigurePreset 'binaryDir'
+    $BinaryDirectory = ResolvePresetProperty -CMakePresetsJson $CMakePresetsJson $ConfigurePreset 'binaryDir'
 
     # Perform macro-replacement
     $Result = MacroReplacement $BinaryDirectory $ConfigurePreset

--- a/PSCMake/Common/CMake.ps1
+++ b/PSCMake/Common/CMake.ps1
@@ -38,8 +38,8 @@ $CMakeCandidates = @(
 )
 
 <#
- .Synopsis
-  Finds the root of the CMake build - the current or ancestral folder containing a 'CMakePresets.json' file.
+    .Synopsis
+    Finds the root of the CMake build - the current or ancestral folder containing a 'CMakePresets.json' file.
 #>
 function FindCMakeRoot {
     $CurrentLocation = (Get-Location).Path
@@ -49,16 +49,16 @@ function FindCMakeRoot {
 $script:CMakePresetsPath = $null
 
 <#
- .Synopsis
-  Gets the path that the most recently loaded CMakePresets.json was loaded from.
+    .Synopsis
+    Gets the path that the most recently loaded CMakePresets.json was loaded from.
 #>
 function GetCMakePresetsPath {
     $script:CMakePresetsPath
 }
 
 <#
- .Synopsis
-  Loads the CMakePresets.json into a PowerShell representation.
+    .Synopsis
+    Loads the CMakePresets.json into a PowerShell representation.
 #>
 function GetCMakePresets {
     param(
@@ -77,8 +77,8 @@ function GetCMakePresets {
 }
 
 <#
- .Synopsis
-  Gets names of the 'buildPresets' in the specified CMakePresets.json object.
+    .Synopsis
+    Gets names of the 'buildPresets' in the specified CMakePresets.json object.
 #>
 function GetBuildPresetNames {
     param(
@@ -106,8 +106,8 @@ function GetBuildPresetNames {
 }
 
 <#
- .Synopsis
-  Gets names of the 'configurePresets' in the specified CMakePresets.json object.
+    .Synopsis
+    Gets names of the 'configurePresets' in the specified CMakePresets.json object.
 #>
 function GetConfigurePresetNames {
     param(
@@ -127,8 +127,8 @@ function GetConfigurePresetNames {
 }
 
 <#
- .Synopsis
-  Finds the 'CMake' command.
+    .Synopsis
+    Finds the 'CMake' command.
 #>
 function GetCMake {
     $CMake = Get-Variable -Name 'CMake' -ValueOnly -Scope global -ErrorAction SilentlyContinue
@@ -412,11 +412,11 @@ function Get-CMakeBuildCodeModelDirectory {
 }
 
 <#
- .Synopsis
-  Gets PowerShell representation of the CodeModel JSON for the given binary directory.
+    .Synopsis
+    Gets PowerShell representation of the CodeModel JSON for the given binary directory.
 
- .Outputs
-  The PowerShell representation of the CodeModel JSON for the given binary directory, or `$null` if it can't be found.
+    .Outputs
+    The PowerShell representation of the CodeModel JSON for the given binary directory, or `$null` if it can't be found.
 #>
 function Get-CMakeBuildCodeModel {
     param(
@@ -429,11 +429,11 @@ function Get-CMakeBuildCodeModel {
 }
 
 <#
- .Synopsis
-  Gets the target with the given name, for the given configuration from the specified code model.
+    .Synopsis
+    Gets the target with the given name, for the given configuration from the specified code model.
 
- .Outputs
-  The PowerShell representation of the target from the CodeModel JSON.
+    .Outputs
+    The PowerShell representation of the target from the CodeModel JSON.
 #>
 function GetNamedTarget {
     param(
@@ -453,11 +453,11 @@ function GetNamedTarget {
 }
 
 <#
- .Synopsis
-  Gets all targets within the given folder scope, for the given configuration from the specified code model.
+    .Synopsis
+    Gets all targets within the given folder scope, for the given configuration from the specified code model.
 
- .Outputs
-  The PowerShell representation of the target(s) from the CodeModel JSON.
+    .Outputs
+    The PowerShell representation of the target(s) from the CodeModel JSON.
 #>
 function GetScopedTargets {
     param(

--- a/PSCMake/Common/Common.ps1
+++ b/PSCMake/Common/Common.ps1
@@ -1,7 +1,7 @@
 #----------------------------------------------------------------------------------------------------------------------
 # MIT License
 #
-# Copyright (c) 2021 Mark Schofield
+# Copyright (c) 2025 Mark Schofield
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/PSCMake/Common/Common.ps1
+++ b/PSCMake/Common/Common.ps1
@@ -37,8 +37,8 @@ function Get-MemberValue {
 }
 
 <#
- .Synopsis
-  Performs linear interpolation from the first color to the second.
+    .Synopsis
+    Performs linear interpolation from the first color to the second.
 #>
 function ColorInterpolation {
     param(
@@ -56,8 +56,8 @@ function ColorInterpolation {
 }
 
 <#
- .Synopsis
-  Checks whether the given file is newer than any subsequently specified files.
+    .Synopsis
+    Checks whether the given file is newer than any subsequently specified files.
 #>
 function IsUpToDate($Target) {
     $Dependencies = $args
@@ -96,8 +96,8 @@ function DownloadFile([string] $Url, [string] $DownloadPath) {
 }
 
 <#
- .Synopsis
-  Searches the given location and parent folders looking for the given file.
+    .Synopsis
+    Searches the given location and parent folders looking for the given file.
 #>
 function GetPathOfFileAbove([string]$Location, [string]$File) {
     for (; $Location.Length -ne 0; $Location = Split-Path $Location) {
@@ -109,8 +109,8 @@ function GetPathOfFileAbove([string]$Location, [string]$File) {
 }
 
 <#
- .Synopsis
-  Converts named items on a Pipeline into a hash table.
+    .Synopsis
+    Converts named items on a Pipeline into a hash table.
 #>
 filter ToHashTable {
     begin { $Result = @{} }

--- a/PSCMake/Common/Console.ps1
+++ b/PSCMake/Common/Console.ps1
@@ -1,7 +1,7 @@
 #----------------------------------------------------------------------------------------------------------------------
 # MIT License
 #
-# Copyright (c) 2021 Mark Schofield
+# Copyright (c) 2025 Mark Schofield
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/PSCMake/Common/Console.ps1
+++ b/PSCMake/Common/Console.ps1
@@ -74,11 +74,11 @@ function GetConsole {
 }
 
 <#
- .Synopsis
-  Returns whether virtual terminal processing is enabled for the current console.
+    .Synopsis
+    Returns whether virtual terminal processing is enabled for the current console.
 
- .Outputs
- `$true` if virtual terminal processing is enabled, `$false` otherwise.
+    .Outputs
+    `$true` if virtual terminal processing is enabled, `$false` otherwise.
 #>
 function IsVirtualTerminalProcessingEnabled {
     if ($null -eq $script:IsVirtualTerminalProcessingEnabled) {
@@ -101,8 +101,8 @@ function IsVirtualTerminalProcessingEnabled {
 }
 
 <#
- .Synopsis
-  Returns the control codes to set the foreground color to the specified value.
+    .Synopsis
+    Returns the control codes to set the foreground color to the specified value.
 #>
 function ColorToControlCode {
     param(
@@ -114,8 +114,8 @@ function ColorToControlCode {
 }
 
 <#
- .Synopsis
-  Returns the control codes to reset foreground attributes, if virtual terminal processing is enable.
+    .Synopsis
+    Returns the control codes to reset foreground attributes, if virtual terminal processing is enable.
 #>
 function ResetForegroundControlCode {
     if (IsVirtualTerminalProcessingEnabled) {

--- a/PSCMake/Common/Ninja.ps1
+++ b/PSCMake/Common/Ninja.ps1
@@ -1,7 +1,7 @@
 #----------------------------------------------------------------------------------------------------------------------
 # MIT License
 #
-# Copyright (c) 2021 Mark Schofield
+# Copyright (c) 2025 Mark Schofield
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/PSCMake/Common/Ninja.ps1
+++ b/PSCMake/Common/Ninja.ps1
@@ -116,8 +116,8 @@ function Report-NinjaBuild {
 function Download-Ninja {
     param(
         [string] $OutputPath,
-        $NinjaVersion = '1.11.1',
-        $NinjaArchiveSha256Hash = '524B344A1A9A55005EAF868D991E090AB8CE07FA109F1820D40E74642E289ABC'
+        $NinjaVersion = '1.13.1',
+        $NinjaArchiveSha256Hash = '26a40fa8595694dec2fad4911e62d29e10525d2133c9a4230b66397774ae25bf'
     )
     $NinjaArchiveUrl = "https://github.com/ninja-build/ninja/releases/download/v$NinjaVersion/ninja-win.zip"
     $NinjaArchivePath = Join-Path -Path $OutputPath -ChildPath 'ninja-win.zip'

--- a/PSCMake/Common/Ninja.ps1
+++ b/PSCMake/Common/Ninja.ps1
@@ -30,11 +30,11 @@ $ErrorActionPreference = 'Stop'
 . $PSScriptRoot/Console.ps1
 
 <#
- .Synopsis
-  Tries to parse the specified Ninja log.
+    .Synopsis
+    Tries to parse the specified Ninja log.
 
- .Outputs
- The entries from the Ninja log.
+    .Outputs
+    The entries from the Ninja log.
 #>
 function TryParseNinjaLog {
     [CmdletBinding()]
@@ -63,11 +63,11 @@ function TryParseNinjaLog {
 $FileTimeOffset = [long]12622770400 * [long]10000000
 
 <#
- .Synopsis
-  Converts the specified Ninja log time representation into a [datetime].
+    .Synopsis
+    Converts the specified Ninja log time representation into a [datetime].
 
- .Notes
- This function is currently Windows-only.
+    .Notes
+    This function is currently Windows-only.
 #>
 function ConvertFrom-NinjaTime {
     param(
@@ -77,11 +77,11 @@ function ConvertFrom-NinjaTime {
 }
 
 <#
- .Synopsis
-  Converts the specified [datetime] into Ninja log time representation.
+    .Synopsis
+    Converts the specified [datetime] into Ninja log time representation.
 
- .Notes
- This function is currently Windows-only.
+    .Notes
+    This function is currently Windows-only.
 #>
 function ConvertTo-NinjaTime {
     param(

--- a/PSCMake/PSCMake.psm1
+++ b/PSCMake/PSCMake.psm1
@@ -1,7 +1,7 @@
 #----------------------------------------------------------------------------------------------------------------------
 # MIT License
 #
-# Copyright (c) 2021 Mark Schofield
+# Copyright (c) 2025 Mark Schofield
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/PSCMake/PSCMake.psm1
+++ b/PSCMake/PSCMake.psm1
@@ -42,6 +42,10 @@ function BuildPresetsCompleter {
         $CommandAst,
         $FakeBoundParameters
     )
+    $null = $CommandName
+    $null = $ParameterName
+    $null = $CommandAst
+    $null = $FakeBoundParameters
     $CMakePresetsJson = GetCMakePresets -Silent
     GetBuildPresetNames $CMakePresetsJson | Where-Object { $_ -ilike "$WordToComplete*" }
 }
@@ -58,6 +62,11 @@ function BuildConfigurationsCompleter {
         $CommandAst,
         $FakeBoundParameters
     )
+    $null = $CommandName
+    $null = $ParameterName
+    $null = $CommandAst
+    $null = $FakeBoundParameters
+
     # TODO: A meaningful implementation would:
     #   * If a buildPreset can be resolved, see if it has a `configuration` and use that.
     #   * If not, look for a code model and use that.
@@ -83,6 +92,9 @@ function BuildTargetsCompleter {
         $CommandAst,
         $FakeBoundParameters
     )
+    $null = $CommandName
+    $null = $ParameterName
+    $null = $CommandAst
     $CMakePresetsJson = GetCMakePresets -Silent
     $PresetNames = GetBuildPresetNames $CMakePresetsJson
     $PresetName = $FakeBoundParameters['Presets'] ?? $PresetNames |
@@ -127,6 +139,9 @@ function ExecutableTargetsCompleter {
         $CommandAst,
         $FakeBoundParameters
     )
+    $null = $CommandName
+    $null = $ParameterName
+    $null = $CommandAst
     $CMakePresetsJson = GetCMakePresets -Silent
     $PresetNames = GetBuildPresetNames $CMakePresetsJson
     $PresetName = $FakeBoundParameters['Presets'] ?? $PresetNames |
@@ -161,6 +176,10 @@ function ConfigurePresetsCompleter {
         $CommandAst,
         $FakeBoundParameters
     )
+    $null = $CommandName
+    $null = $ParameterName
+    $null = $CommandAst
+    $null = $FakeBoundParameters
     $CMakePresetsJson = GetCMakePresets -Silent
     GetConfigurePresetNames $CMakePresetsJson | Where-Object { $_ -ilike "$WordToComplete*" }
 }
@@ -242,7 +261,7 @@ function Configure-CMakeBuild {
                 Write-Error "Unable to find configuration preset '$Preset' in $script:CMakePresetsPath"
             }
 
-            ConfigureCMake $CMake $CMakePresetsJson $ConfigurePreset -Fresh:$Fresh
+            ConfigureCMake -CMake $CMake $CMakePresetsJson $ConfigurePreset -Fresh:$Fresh
         }
     }
 }
@@ -337,7 +356,7 @@ function Build-CMakeBuild {
                 $Fresh -or
                 (-not (Test-Path -Path $CMakeCacheFile -PathType Leaf)) -or
                 (-not (Test-Path -Path (Get-CMakeBuildCodeModelDirectory $BinaryDirectory) -PathType Container))) {
-                ConfigureCMake $CMake $CMakePresetsJson $ConfigurePreset -Fresh:$Fresh
+                ConfigureCMake -CMake $CMake $CMakePresetsJson $ConfigurePreset -Fresh:$Fresh
             }
 
             $CodeModel = Get-CMakeBuildCodeModel $BinaryDirectory

--- a/PSCMake/PSCMake.psm1
+++ b/PSCMake/PSCMake.psm1
@@ -31,8 +31,8 @@ $ErrorActionPreference = 'Stop'
 . $PSScriptRoot/Common/Ninja.ps1
 
 <#
- .Synopsis
-  An argument-completer for `Build-CMakeBuild`'s `-Preset` parameter.
+    .Synopsis
+    An argument-completer for `Build-CMakeBuild`'s `-Preset` parameter.
 #>
 function BuildPresetsCompleter {
     param(
@@ -47,8 +47,8 @@ function BuildPresetsCompleter {
 }
 
 <#
- .Synopsis
-  An argument-completer for `Build-CMakeBuild`'s `-Configurations` parameter.
+    .Synopsis
+    An argument-completer for `Build-CMakeBuild`'s `-Configurations` parameter.
 #>
 function BuildConfigurationsCompleter {
     param(
@@ -72,8 +72,8 @@ function BuildConfigurationsCompleter {
 }
 
 <#
- .Synopsis
-  An argument-completer for `Build-CMakeBuild`'s `-Targets` parameter.
+    .Synopsis
+    An argument-completer for `Build-CMakeBuild`'s `-Targets` parameter.
 #>
 function BuildTargetsCompleter {
     param(
@@ -116,8 +116,8 @@ function BuildTargetsCompleter {
 }
 
 <#
- .Synopsis
-  An argument-completer for `Build-CMakeBuild`'s `-Targets` parameter.
+    .Synopsis
+    An argument-completer for `Build-CMakeBuild`'s `-Targets` parameter.
 #>
 function ExecutableTargetsCompleter {
     param(
@@ -150,8 +150,8 @@ function ExecutableTargetsCompleter {
 }
 
 <#
- .Synopsis
-  An argument-completer for `Configure-CMakeBuild`'s `-Presets` parameter.
+    .Synopsis
+    An argument-completer for `Configure-CMakeBuild`'s `-Presets` parameter.
 #>
 function ConfigurePresetsCompleter {
     param(
@@ -199,21 +199,21 @@ function ConfigureCMake {
 }
 
 <#
- .Synopsis
-  Configures a CMake build.
+    .Synopsis
+    Configures a CMake build.
 
- .Description
-  Configures the specified 'configurePresets' entries from a CMakePresets.json file in the current-or-higher folder.
+    .Description
+    Configures the specified 'configurePresets' entries from a CMakePresets.json file in the current-or-higher folder.
 
- .Parameter Presets
-  The configure preset names to use.
+    .Parameter Presets
+    The configure preset names to use.
 
- .Parameter Fresh
-  A switch specifying whether a 'fresh' configuration is performed - removing any existing cache.
+    .Parameter Fresh
+    A switch specifying whether a 'fresh' configuration is performed - removing any existing cache.
 
- .Example
-   # Configure the 'windows-x64' and 'windows-x86' CMake builds.
-   Configure-CMakeBuild -Presets windows-x64,windows-x86
+    .Example
+    # Configure the 'windows-x64' and 'windows-x86' CMake builds.
+    Configure-CMakeBuild -Presets windows-x64,windows-x86
 #>
 function Configure-CMakeBuild {
     [CmdletBinding()]
@@ -248,38 +248,38 @@ function Configure-CMakeBuild {
 }
 
 <#
- .Synopsis
-  Builds a CMake build.
+    .Synopsis
+    Builds a CMake build.
 
- .Description
-  Builds the specified 'buildPresets' entries from a CMakePresets.json file in the current-or-higher folder.
+    .Description
+    Builds the specified 'buildPresets' entries from a CMakePresets.json file in the current-or-higher folder.
 
- .Parameter Presets
+    .Parameter Presets
 
- .Parameter Configurations
+    .Parameter Configurations
 
- .Parameter Targets
-   One or more
+    .Parameter Targets
+    One or more
 
- .Parameter Configure
-   A switch specifying whether the necessary configuration should be performed before the build is run.
+    .Parameter Configure
+    A switch specifying whether the necessary configuration should be performed before the build is run.
 
- .Parameter Report
-   [Exploration] A switch specifying whether a report should be written of the command times of the build. Ninja builds only.
+    .Parameter Report
+    [Exploration] A switch specifying whether a report should be written of the command times of the build. Ninja builds only.
 
- .Parameter Fresh
-   A switch specifying whether a 'fresh' configuration should be performed before the build is run.
+    .Parameter Fresh
+    A switch specifying whether a 'fresh' configuration should be performed before the build is run.
 
- .Example
-   # Build the 'windows-x64' and 'windows-x86' CMake builds.
-   Build-CMakeBuild -Presets windows-x64,windows-x86
+    .Example
+    # Build the 'windows-x64' and 'windows-x86' CMake builds.
+    Build-CMakeBuild -Presets windows-x64,windows-x86
 
-   # Build the 'windows-x64' and 'windows-x86' CMake builds, with the 'Release' configuration.
-   Build-CMakeBuild -Presets windows-x64,windows-x86 -Configurations Release
+    # Build the 'windows-x64' and 'windows-x86' CMake builds, with the 'Release' configuration.
+    Build-CMakeBuild -Presets windows-x64,windows-x86 -Configurations Release
 
-   # Build the 'HelperLibrary' target, for the 'windows-x64' and 'windows-x86' CMake builds, with the 'Release'
-   # configuration.
-   Build-CMakeBuild -Presets windows-x64,windows-x86 -Configurations Release -Targets HelperLibrary
+    # Build the 'HelperLibrary' target, for the 'windows-x64' and 'windows-x86' CMake builds, with the 'Release'
+    # configuration.
+    Build-CMakeBuild -Presets windows-x64,windows-x86 -Configurations Release -Targets HelperLibrary
 #>
 function Build-CMakeBuild {
     [CmdletBinding()]
@@ -420,30 +420,29 @@ function Write-CMakeBuild {
 }
 
 <#
- .Synopsis
- Runs the output of a CMake build.
+    .Synopsis
+    Runs the output of a CMake build.
 
- .Description
- `Invoke-CMakeOutput` runs the output of a CMake build. A {preset,configuration,target} can be specified, and `Invoke-CMakeOutput`
- will build the target, use the CMake code-model to discover the path to the generated executable and run it, passing any
- extra parameter specified. If `Invoke-CMakeOutput` is run from a folder that only contains a single executable target,
- then that target will be built and run.
+    .Description
+    `Invoke-CMakeOutput` runs the output of a CMake build. A {preset,configuration,target} can be specified, and `Invoke-CMakeOutput`
+    will build the target, use the CMake code-model to discover the path to the generated executable and run it, passing any
+    extra parameter specified. If `Invoke-CMakeOutput` is run from a folder that only contains a single executable target,
+    then that target will be built and run.
 
- .Parameter Preset
- The CMake preset to use. If none is specified, then the first valid preset from CMakePresets.json is used.
+    .Parameter Preset
+    The CMake preset to use. If none is specified, then the first valid preset from CMakePresets.json is used.
 
- .Parameter Configuration
- The CMake configuration to use. If none is specified, then the first valid configuration is used.
+    .Parameter Configuration
+    The CMake configuration to use. If none is specified, then the first valid configuration is used.
 
- .Parameter Target
- The CMake target that produces an executable to run.
+    .Parameter Target
+    The CMake target that produces an executable to run.
 
- .Parameter SkipBuild
- If specified, the build will be skipped, otherwise a build will be run before invoking the output.
+    .Parameter SkipBuild
+    If specified, the build will be skipped, otherwise a build will be run before invoking the output.
 
- .Parameter Arguments
- All other parameters will be passed to the discovered executable.
-
+    .Parameter Arguments
+    All other parameters will be passed to the discovered executable.
 #>
 function Invoke-CMakeOutput {
     [CmdletBinding(PositionalBinding = $false)]

--- a/Tests/BuildConfigurationsCompleter.Tests.ps1
+++ b/Tests/BuildConfigurationsCompleter.Tests.ps1
@@ -11,7 +11,7 @@ BeforeAll {
 
 Describe 'BuildConfigurationsCompleter' {
     It 'Returns the default configurations when no preset is specified' {
-        $Completions = Get-CommandCompletions "Build-CMakeBuild -Configurations "
+        $Completions = Get-CommandCompletion "Build-CMakeBuild -Configurations "
         $Completions.CompletionMatches.Count | Should -Be 4
         $Completions.CompletionMatches[0].CompletionText | Should -Be 'Release'
         $Completions.CompletionMatches[1].CompletionText | Should -Be 'Debug'
@@ -20,7 +20,7 @@ Describe 'BuildConfigurationsCompleter' {
     }
 
     It 'Returns the default configurations when no preset is specified, filtered by the word to complete' {
-        $Completions = Get-CommandCompletions "Build-CMakeBuild -Configurations D"
+        $Completions = Get-CommandCompletion "Build-CMakeBuild -Configurations D"
         $Completions.CompletionMatches.Count | Should -Be 1
         $Completions.CompletionMatches[0].CompletionText | Should -Be 'Debug'
     }

--- a/Tests/BuildPresetsCompleter.Tests.ps1
+++ b/Tests/BuildPresetsCompleter.Tests.ps1
@@ -11,14 +11,14 @@ BeforeAll {
 
 Describe 'BuildPresetsCompleter' {
     It 'Returns the presets from the discovered presets file, in the order that they are defined' {
-        $Completions = Get-CommandCompletions "Build-CMakeBuild -Preset "
+        $Completions = Get-CommandCompletion "Build-CMakeBuild -Preset "
         $Completions.CompletionMatches.Count | Should -Be 2
         $Completions.CompletionMatches[0].CompletionText | Should -Be 'windows-x64'
         $Completions.CompletionMatches[1].CompletionText | Should -Be 'windows-arm'
     }
 
     It 'Returns the presets from the discovered presets file, filtered by the word to complete' {
-        $Completions = Get-CommandCompletions "Build-CMakeBuild -Preset windows-a"
+        $Completions = Get-CommandCompletion "Build-CMakeBuild -Preset windows-a"
         $Completions.CompletionMatches.Count | Should -Be 1
         $Completions.CompletionMatches[0].CompletionText | Should -Be 'windows-arm'
     }

--- a/Tests/BuildTargetsCompleter.Tests.ps1
+++ b/Tests/BuildTargetsCompleter.Tests.ps1
@@ -18,7 +18,7 @@ BeforeAll {
 Describe 'BuildTargetsCompleter' {
     It 'Returns the targets of the default preset, default configuration when neither is specified' {
         Using-Location "$PSScriptRoot/ReferenceBuild" {
-            $Completions = Get-CommandCompletions "Build-CMakeBuild -Targets "
+            $Completions = Get-CommandCompletion "Build-CMakeBuild -Targets "
 
             $Completions.CompletionMatches.Count | Should -Be 6
             $Completions.CompletionMatches[0].CompletionText | Should -Be 'A_Library'

--- a/Tests/Get-MemberValue.Tests.ps1
+++ b/Tests/Get-MemberValue.Tests.ps1
@@ -3,24 +3,24 @@
 BeforeAll {
     . $PSScriptRoot/../PSCMake/Common/Common.ps1
 
-    $TestObject = [PSCustomObject]@{
+    $script:TestObject = [PSCustomObject]@{
         Breakfast = 'Chunky Bacon'
     }
 }
 
 Describe 'Get-MemberValue' {
     It 'Returns the member value when available' {
-        Get-MemberValue -InputObject $TestObject -Name Breakfast -Or Cereal |
+        Get-MemberValue -InputObject $script:TestObject -Name Breakfast -Or Cereal |
             Should -Be 'Chunky Bacon'
     }
 
     It 'Returns null when the member value is not available' {
-        Get-MemberValue -InputObject $TestObject -Name Lunch |
+        Get-MemberValue -InputObject $script:TestObject -Name Lunch |
             Should -BeNullOrEmpty
     }
 
     It 'Returns the -Or value when the member value is not available' {
-        Get-MemberValue -InputObject $TestObject -Name Lunch -Or Sandwich |
+        Get-MemberValue -InputObject $script:TestObject -Name Lunch -Or Sandwich |
             Should -Be Sandwich
     }
 }

--- a/Tests/MacroReplacement.Tests.ps1
+++ b/Tests/MacroReplacement.Tests.ps1
@@ -14,7 +14,7 @@ BeforeAll {
         'C:\chunky\bacon\CMakePresets.json'
     }
 
-    $PresetJson = ConvertFrom-Json -InputObject @'
+    $script:PresetJson = ConvertFrom-Json -InputObject @'
     {
         "name": "windows-x64",
         "configurePreset": "windows-x64"

--- a/Tests/TestUtilities.ps1
+++ b/Tests/TestUtilities.ps1
@@ -3,6 +3,6 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-function Get-CommandCompletions([string] $InputScript) {
+function Get-CommandCompletion([string] $InputScript) {
     [System.Management.Automation.CommandCompletion]::CompleteInput($InputScript, $InputScript.Length, $null)
 }

--- a/Tests/Using-Location.Tests.ps1
+++ b/Tests/Using-Location.Tests.ps1
@@ -3,13 +3,13 @@
 BeforeAll {
     . $PSScriptRoot/../PSCMake/Common/Common.ps1
 
-    $OriginalLocation = Get-Location
+    $script:OriginalLocation = Get-Location
     $TestFolder = Join-Path -Path $PSScriptRoot -ChildPath '__test'
     $null = New-Item -Path $TestFolder -ItemType Directory -Force -ErrorAction SilentlyContinue
 }
 
 AfterAll {
-    Set-Location $OriginalLocation
+    Set-Location $script:OriginalLocation
 }
 
 Describe 'Using-Location' {


### PR DESCRIPTION
A handful of pieces of cleanup:

* Update copyright dates - Update copyright dates, to keep things fresh.
* Canonicalize banner comments - The indentation of the function banner comments was inconsistent; snapping to tab-indentation
* Default ninja download to v1.13.1 - The code to download Ninja should default to the latest - v1.13.1
* Fix PSScriptAnalyzer errors - Fix most PSScriptAnalyzer warnings:
  * Avoid 'global' parameters, use 'script'-scope.
  * Use explicit scoping for test variables
  * Use currently unused parameters
  * Rename 'Get-CommandCompletions' --> 'Get-CommandCompletion' (i.e. avoid use a singular noun, not plural).