### PR TITLE
'-Preset' values should be checked for equality before wildcard match

### DIFF
--- a/PSCMake/PSCMake.psm1
+++ b/PSCMake/PSCMake.psm1
@@ -251,7 +251,7 @@ function Configure-CMakeBuild {
         $ConfigurePresetNames | Select-Object -First 1
     } else {
         foreach ($CandidatePreset in $Preset) {
-            $ConfigurePresetNames | Where-Object { $_ -like $CandidatePreset }
+            $ConfigurePresetNames | Where-Object { ($_ -eq $CandidatePreset) -or ($_ -like $CandidatePreset) }
         }
     }
 
@@ -340,7 +340,7 @@ function Build-CMakeBuild {
         $BuildPresetNames | Select-Object -First 1
     } else {
         foreach ($CandidatePreset in $Preset) {
-            $BuildPresetNames | Where-Object { $_ -like $CandidatePreset }
+            $BuildPresetNames | Where-Object { ($_ -eq $CandidatePreset) -or ($_ -like $CandidatePreset) }
         }
     }
 
@@ -378,7 +378,7 @@ function Build-CMakeBuild {
             [string[]] $ConfigurationNames = @($null)
             if ($Configuration) {
                 $ConfigurationNames = foreach ($CandidateConfigurationName in $Configuration) {
-                    $CodeModel.configurations.name | Where-Object { $_ -like $CandidateConfigurationName }
+                    $CodeModel.configurations.name | Where-Object { ($_ -eq $CandidateConfigurationName) -or ($_ -like $CandidateConfigurationName) }
                 }
             }
 


### PR DESCRIPTION
Fixes #66.

Now that -Preset and -Configuration parameters can be wildcards, matching against `[` and `]` is broken - since PowerShell interprets that as a character set. This means that asking to build a preset called - say - `windows-x64[asan]` will not do any work, since `'windows-x64[asan]' -like 'windows-x64[asan]'` is `false`. Testing for `-eq` first is a reasonable accommodation, but, say, `*-x64[asan]` would only match the wildcard syntax; you'd have to

```
*-x64`[asan`]
```