### PR TITLE
Fix over-matching on implicitly scoped targets

### DIFF
--- a/PSCMake/Common/CMake.ps1
+++ b/PSCMake/Common/CMake.ps1
@@ -507,6 +507,10 @@ function GetScopedTargets {
         $Configuration,
         $ScopeLocation
     )
+    function CanonicalizeDirectoryPath($Path) {
+        Resolve-Path -Path (Join-Path -Path $Path -ChildPath '/')
+    }
+    $ScopeLocation = CanonicalizeDirectoryPath $ScopeLocation
     $CodeModelConfiguration = if ($Configuration) {
         $CodeModel.configurations | Where-Object { $_.name -eq $Configuration }
     } else {
@@ -521,7 +525,8 @@ function GetScopedTargets {
             } else {
                 Join-Path -Path $SourceDir -ChildPath $Folder
             }
-            $Folder.StartsWith($ScopeLocation)
+            $Folder = CanonicalizeDirectoryPath $Folder
+            $Folder.Path.StartsWith($ScopeLocation.Path)
         }
 }
 

--- a/Tests/BuildTargetsCompleter.Tests.ps1
+++ b/Tests/BuildTargetsCompleter.Tests.ps1
@@ -20,13 +20,19 @@ Describe 'BuildTargetsCompleter' {
         Using-Location "$PSScriptRoot/ReferenceBuild" {
             $Completions = Get-CommandCompletion "Build-CMakeBuild -Targets "
 
-            $Completions.CompletionMatches.Count | Should -Be 6
-            $Completions.CompletionMatches[0].CompletionText | Should -Be 'A_Library'
-            $Completions.CompletionMatches[1].CompletionText | Should -Be 'B_Library'
-            $Completions.CompletionMatches[2].CompletionText | Should -Be 'C_Library'
-            $Completions.CompletionMatches[3].CompletionText | Should -Be 'all'
-            $Completions.CompletionMatches[4].CompletionText | Should -Be 'clean'
-            $Completions.CompletionMatches[5].CompletionText | Should -Be 'install'
+            $Completions.CompletionMatches.Count | Should -Be 10
+            $Completions.CompletionMatches.CompletionText | Should -Be @(
+                'A_Library'
+                'B_Library'
+                'C_Library'
+                'SubDirectoryOther_Executable'
+                'SubDirectoryOther_Library'
+                'SubDirectory_Executable'
+                'SubDirectory_Library'
+                'all'
+                'clean'
+                'install'
+            )
         }
     }
 }

--- a/Tests/GetScopedTargets.Tests.ps1
+++ b/Tests/GetScopedTargets.Tests.ps1
@@ -1,0 +1,57 @@
+#Requires -PSEdition Core
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+BeforeAll {
+    . $PSScriptRoot/TestUtilities.ps1
+    . $PSScriptRoot/ReferenceBuild.ps1
+
+    $Properties = PrepareReferenceBuild
+
+    $CMake = "$env:ProgramFiles/CMake/bin/cmake.exe"
+    & $CMake @Properties
+
+    . $PSScriptRoot/../PSCMake/Common/CMake.ps1
+
+    $ReferenceBuildProperties = GetReferenceBuildProperties
+    $CodeModel = Get-CMakeBuildCodeModel $ReferenceBuildProperties.BinaryDirectory
+    $script:SourceLocation = $CodeModel.paths.source
+}
+
+Describe 'GetScopedTargets' {
+    It 'Returns all targets when the ScopeLocation is the SourceLocation' {
+        $ScopeLocation = $SourceLocation
+        $Targets = GetScopedTargets $CodeModel $null $ScopeLocation
+        $Targets.name |
+            Should -Be @(
+                'A_Library'
+                'B_Library'
+                'C_Library'
+                'SubDirectoryOther_Executable'
+                'SubDirectoryOther_Library'
+                'SubDirectory_Executable'
+                'SubDirectory_Library'
+            )
+    }
+
+    It 'Returns scoped targets when the ScopeLocation is a subdirectory of the SourceLocation' {
+        $ScopeLocation = Join-Path -Path $SourceLocation -ChildPath 'SubDirectoryOther'
+        $Targets = GetScopedTargets $CodeModel $null $ScopeLocation
+        $Targets.name |
+            Should -Be @(
+                'SubDirectoryOther_Executable'
+                'SubDirectoryOther_Library'
+            )
+    }
+
+    It 'Returns scoped targets when the ScopeLocation is a subdirectory of the SourceLocation, that is also a prefix of another subdirectory' {
+        $ScopeLocation = Join-Path -Path $SourceLocation -ChildPath 'SubDirectory'
+        $Targets = GetScopedTargets $CodeModel $null $ScopeLocation
+        $Targets.name |
+            Should -Be @(
+                'SubDirectory_Executable'
+                'SubDirectory_Library'
+            )
+    }
+}

--- a/Tests/ReferenceBuild.ps1
+++ b/Tests/ReferenceBuild.ps1
@@ -41,3 +41,12 @@ function PrepareReferenceBuild() {
         "-DCMAKE_MAKE_PROGRAM=$CMAKE_MAKE_PROGRAM"
     )
 }
+
+function GetReferenceBuildProperties() {
+    $BinaryDirectory = "$PSScriptRoot/ReferenceBuild/__output/windows-x64"
+
+    [PSCustomObject]@{
+        BinaryDirectory = $BinaryDirectory
+        CodeModelFile = Get-CMakeBuildCodeModel $BinaryDirectory
+    }
+}

--- a/Tests/ReferenceBuild/CMakeLists.txt
+++ b/Tests/ReferenceBuild/CMakeLists.txt
@@ -16,3 +16,6 @@ add_library(B_Library
 add_library(C_Library
     Reference.cpp
 )
+
+add_subdirectory(SubDirectory)
+add_subdirectory(SubDirectoryOther)

--- a/Tests/ReferenceBuild/SubDirectory/CMakeLists.txt
+++ b/Tests/ReferenceBuild/SubDirectory/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_executable(SubDirectory_Executable
+    ../Reference.cpp
+)
+
+add_library(SubDirectory_Library
+    ../Reference.cpp
+)

--- a/Tests/ReferenceBuild/SubDirectoryOther/CMakeLists.txt
+++ b/Tests/ReferenceBuild/SubDirectoryOther/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_executable(SubDirectoryOther_Executable
+    ../Reference.cpp
+)
+
+add_library(SubDirectoryOther_Library
+    ../Reference.cpp
+)

--- a/Tests/Write-CMakeBuild.Tests.ps1
+++ b/Tests/Write-CMakeBuild.Tests.ps1
@@ -23,6 +23,10 @@ digraph CodeModel {
   "A_Library::@6890427a1f51a3e7e1df" [label="A_Library"]
   "B_Library::@6890427a1f51a3e7e1df" [label="B_Library"]
   "C_Library::@6890427a1f51a3e7e1df" [label="C_Library"]
+  "SubDirectoryOther_Executable::@01210d55993b56455dd6" [label="SubDirectoryOther_Executable"]
+  "SubDirectoryOther_Library::@01210d55993b56455dd6" [label="SubDirectoryOther_Library"]
+  "SubDirectory_Executable::@c68b9f6dab07fa391196" [label="SubDirectory_Executable"]
+  "SubDirectory_Library::@c68b9f6dab07fa391196" [label="SubDirectory_Library"]
 }
 '@
             ((Write-CMakeBuild) -join '') |


### PR DESCRIPTION
Fixes #36.

When finding scoped targets to build, PSCMake looks for targets in folders that 'start with' the current folder path. But it's possible for a sibling folder (that has a name that is a prefix of the current folder) would also match. This PR fixes that by canonicalizing the folder paths and ensuring a trailing slash is included. Tests have been added to verify the behavior, expanding the ReferenceBuild to cover the use case.