### PR TITLE
Improve tests for Build-CMakeBuild and Configure-CMakeBuild

### DIFF
--- a/PSCMake/PSCMake.psm1
+++ b/PSCMake/PSCMake.psm1
@@ -251,7 +251,8 @@ function Configure-CMakeBuild {
         $ConfigurePresetNames | Select-Object -First 1
     } else {
         foreach ($CandidatePreset in $Preset) {
-            $ConfigurePresetNames | Where-Object { ($_ -eq $CandidatePreset) -or ($_ -like $CandidatePreset) }
+            $ExpandedPresets = $ConfigurePresetNames | Where-Object { $_ -like $CandidatePreset }
+            $ExpandedPresets ?? $CandidatePreset
         }
     }
 
@@ -340,7 +341,8 @@ function Build-CMakeBuild {
         $BuildPresetNames | Select-Object -First 1
     } else {
         foreach ($CandidatePreset in $Preset) {
-            $BuildPresetNames | Where-Object { ($_ -eq $CandidatePreset) -or ($_ -like $CandidatePreset) }
+            $ExpandedPresets = $BuildPresetNames | Where-Object { $_ -like $CandidatePreset }
+            $ExpandedPresets ?? $CandidatePreset
         }
     }
 
@@ -378,7 +380,8 @@ function Build-CMakeBuild {
             [string[]] $ConfigurationNames = @($null)
             if ($Configuration) {
                 $ConfigurationNames = foreach ($CandidateConfigurationName in $Configuration) {
-                    $CodeModel.configurations.name | Where-Object { ($_ -eq $CandidateConfigurationName) -or ($_ -like $CandidateConfigurationName) }
+                    $ExpandedName = $CodeModel.configurations.name | Where-Object { $_ -like $CandidateConfigurationName }
+                    $ExpandedName ?? $CandidateConfigurationName
                 }
             }
 

--- a/Tests/Build-CMakeBuild.Tests.ps1
+++ b/Tests/Build-CMakeBuild.Tests.ps1
@@ -39,6 +39,53 @@ Describe 'Build-CMakeBuild' {
         $script:CMakeCalls[0] | Should -Be @('--build', '--preset', 'windows-x64')
     }
 
+    It 'Builds with a single preset' {
+        Using-Location "$PSScriptRoot/ReferenceBuild" {
+            Build-CMakeBuild -Preset windows-x64
+        }
+
+        $script:CMakeCalls | Should -HaveCount 1
+        $script:CMakeCalls[0] | Should -Be @('--build', '--preset', 'windows-x64')
+    }
+
+    It 'Builds a specified target' {
+        Using-Location "$PSScriptRoot/ReferenceBuild" {
+            Build-CMakeBuild -Preset windows-x64 -Target B_Library
+        }
+
+        $script:CMakeCalls | Should -HaveCount 1
+        $script:CMakeCalls[0] | Should -Be @('--build', '--preset', 'windows-x64', '--target', 'B_Library')
+    }
+
+    It 'Builds a multiple targets' {
+        Using-Location "$PSScriptRoot/ReferenceBuild" {
+            Build-CMakeBuild -Preset windows-x64 -Target A_Library,B_Library
+        }
+
+        $script:CMakeCalls | Should -HaveCount 1
+        $script:CMakeCalls[0] | Should -Be @('--build', '--preset', 'windows-x64', '--target', 'A_Library', 'B_Library')
+    }
+
+    It 'Reruns configuration with -Configure' {
+        Using-Location "$PSScriptRoot/ReferenceBuild" {
+            Build-CMakeBuild -Preset windows-x64 -Configure
+        }
+
+        $script:CMakeCalls | Should -HaveCount 2
+        $script:CMakeCalls[0] | Should -Be @('--preset', 'windows-x64')
+        $script:CMakeCalls[1] | Should -Be @('--build', '--preset', 'windows-x64')
+    }
+
+    It 'Reruns configuration with -Fresh' {
+        Using-Location "$PSScriptRoot/ReferenceBuild" {
+            Build-CMakeBuild -Preset windows-x64 -Fresh
+        }
+
+        $script:CMakeCalls | Should -HaveCount 2
+        $script:CMakeCalls[0] | Should -Be @('--preset', 'windows-x64', '--fresh')
+        $script:CMakeCalls[1] | Should -Be @('--build', '--preset', 'windows-x64')
+    }
+
     It 'Builds with wildcard presets' {
         Using-Location "$PSScriptRoot/ReferenceBuild" {
             Build-CMakeBuild -Preset '*-x64'
@@ -57,5 +104,14 @@ Describe 'Build-CMakeBuild' {
         $script:CMakeCalls[0] | Should -Be @('--build', '--preset', 'windows-x64', '--config', 'Debug')
         $script:CMakeCalls[1] | Should -Be @('--build', '--preset', 'windows-x64', '--config', 'Release')
         $script:CMakeCalls[2] | Should -Be @('--build', '--preset', 'windows-x64', '--config', 'RelWithDebInfo')
+    }
+
+    It 'Builds scoped targets' {
+        Using-Location "$PSScriptRoot/ReferenceBuild/SubDirectory" {
+            Build-CMakeBuild -Preset 'windows-x64'
+        }
+
+        $CMakeCalls | Should -HaveCount 1
+        $script:CMakeCalls[0] | Should -Be @('--build', '--preset', 'windows-x64', '--target', 'SubDirectory_Executable', 'SubDirectory_Library')
     }
 }

--- a/Tests/Configure-CMakeBuild.Tests.ps1
+++ b/Tests/Configure-CMakeBuild.Tests.ps1
@@ -13,12 +13,82 @@ BeforeAll {
     & $CMake @Properties
 
     Import-Module -Force $PSScriptRoot/../PSCMake/PSCMake.psd1 -DisableNameChecking
+
+    # Mock subsequent calls to invoke CMake so that we don't actually try to build anything.
+    Mock -ModuleName PSCMake InvokeCMake {
+        param(
+            [string] $CMakePath,
+            [string[]] $Arguments
+        )
+        $script:CMakeCalls += , $Arguments
+    }
 }
 
 Describe 'Configure-CMakeBuild' {
+    BeforeEach {
+        $script:CMakeCalls = @()
+    }
+
     It 'Configures the build with no parameters' {
         Using-Location "$PSScriptRoot/ReferenceBuild" {
             Configure-CMakeBuild
+
+            $script:CMakeCalls | Should -HaveCount 1
+            $script:CMakeCalls[0] | Should -Be @('--preset', 'windows-x64')
+        }
+    }
+
+    It 'Configures with --fresh when specified' {
+        Using-Location "$PSScriptRoot/ReferenceBuild" {
+            Configure-CMakeBuild -Fresh
+
+            $script:CMakeCalls | Should -HaveCount 1
+            $script:CMakeCalls[0] | Should -Be @('--preset', 'windows-x64', '--fresh')
+        }
+    }
+
+    It 'Configures with --verbose when specified' {
+        Using-Location "$PSScriptRoot/ReferenceBuild" {
+            Configure-CMakeBuild -Fresh -Verbose
+
+            $script:CMakeCalls | Should -HaveCount 1
+            $script:CMakeCalls[0] | Should -Be @('--preset', 'windows-x64', '--fresh', '--log-level=VERBOSE')
+        }
+    }
+
+    It 'Configures with a specific preset' {
+        Using-Location "$PSScriptRoot/ReferenceBuild" {
+            Configure-CMakeBuild -Preset windows-arm
+
+            $script:CMakeCalls | Should -HaveCount 1
+            $script:CMakeCalls[0] | Should -Be @('--preset', 'windows-arm')
+        }
+    }
+
+    It 'Configures with a multiple presets' {
+        Using-Location "$PSScriptRoot/ReferenceBuild" {
+            Configure-CMakeBuild -Preset windows-arm,windows-x64
+
+            $script:CMakeCalls | Should -HaveCount 2
+            $script:CMakeCalls[0] | Should -Be @('--preset', 'windows-arm')
+            $script:CMakeCalls[1] | Should -Be @('--preset', 'windows-x64')
+        }
+    }
+
+    It 'Configures with a wildcard presets' {
+        Using-Location "$PSScriptRoot/ReferenceBuild" {
+            Configure-CMakeBuild -Preset windows-*
+
+            $script:CMakeCalls | Should -HaveCount 2
+            $script:CMakeCalls[0] | Should -Be @('--preset', 'windows-x64')
+            $script:CMakeCalls[1] | Should -Be @('--preset', 'windows-arm')
+        }
+    }
+
+    It 'Reports invalid presets' {
+        Using-Location "$PSScriptRoot/ReferenceBuild" {
+            { Configure-CMakeBuild -Preset linux-x64 } |
+                Should -Throw "Unable to find configuration preset 'linux-x64' in $PSScriptRoot\ReferenceBuild\CMakePresets.json"
         }
     }
 }


### PR DESCRIPTION
This PR adds more test coverage for Build-CMakeBuild and Configure-CMakeBuild. This did uncover a regression between #63 and #67 - specifying an invalid preset or configuration is no longer an error. When a Preset is passed, all CMakePreset.json presets that match it are chosen. So if _nothing_ matches then no presets are added, and nothing is run. If nothing matches, we now include the originally provided value to either:
1. use that preset incase it was an invalid wildcard (that #67 attempted to fix),
2. cause CMake to consume the preset, and fail as appropriate. 