### PR TITLE
General test cleanup; add Build\RunTests.ps1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,22 +24,10 @@ jobs:
       - name: Invoke-Pester
         shell: pwsh
         run: |
-          Import-Module Pester
-          $Configuration = [PesterConfiguration]@{
-            Run = @{
-              Path = '*'
-              Passthru = $true
-            }
-            CodeCoverage = @{
-              Enabled = $true
-              OutputFormat = 'JaCoCo'
-              OutputPath = '${{ github.workspace }}/Pester-Coverage.xml'
-            }
-          }
-          Invoke-Pester -Configuration $Configuration
+          ${{ github.workspace }}/Build/RunTests.ps1
       - uses: codecov/codecov-action@v5
         with:
-          files: '${{ github.workspace }}/Pester-Coverage.xml'
+          files: '${{ github.workspace }}/__output/coverage.xml'
           flags: unittests
           name: codecov-umbrella
           token: '${{ secrets.CODECOV_TOKEN }}'

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -15,19 +15,7 @@ jobs:
       - name: Invoke-Pester
         shell: pwsh
         run: |
-          Import-Module Pester
-          $Configuration = [PesterConfiguration]@{
-            Run = @{
-              Path = '*'
-              Passthru = $true
-            }
-            CodeCoverage = @{
-              Enabled = $true
-              OutputFormat = 'JaCoCo'
-              OutputPath = '${{ github.workspace }}/Pester-Coverage.xml'
-            }
-          }
-          Invoke-Pester -Configuration $Configuration
+          ${{ github.workspace }}/Build/RunTests.ps1
       - name: Build
         shell: pwsh
         run: |

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
+  "coverage-gutters.coverageBaseDir": "__output",
   "editor.renderWhitespace": "all",
   "powershell.codeFormatting.newLineAfterCloseBrace": false,
   "powershell.codeFormatting.pipelineIndentationStyle": "IncreaseIndentationForFirstPipeline",

--- a/Build/RunTests.ps1
+++ b/Build/RunTests.ps1
@@ -1,0 +1,27 @@
+#Requires -PSEdition Core
+
+[CmdletBinding()]
+param(
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Import-Module Pester
+
+$WorkingDirectory = $PSScriptRoot
+$RepositoryRoot = Resolve-Path -Path (& git -C $WorkingDirectory rev-parse '--show-toplevel')
+$Configuration = [PesterConfiguration]@{
+    Run          = @{
+        Path     = $RepositoryRoot
+        Passthru = $true
+    }
+    CodeCoverage = @{
+        Enabled      = $true
+        Path         = "$RepositoryRoot/PSCMake"
+        OutputFormat = 'JaCoCo'
+        OutputPath   = "$RepositoryRoot/__output/coverage.xml"
+    }
+}
+
+Invoke-Pester -Configuration $Configuration

--- a/Tests/BuildConfigurationsCompleter.Tests.ps1
+++ b/Tests/BuildConfigurationsCompleter.Tests.ps1
@@ -12,7 +12,7 @@ BeforeAll {
 Describe 'BuildConfigurationsCompleter' {
     It 'Returns the default configurations when no preset is specified' {
         $Completions = Get-CommandCompletion "Build-CMakeBuild -Configuration "
-        $Completions.CompletionMatches.Count | Should -Be 4
+        $Completions.CompletionMatches | Should -HaveCount 4
         $Completions.CompletionMatches[0].CompletionText | Should -Be 'Release'
         $Completions.CompletionMatches[1].CompletionText | Should -Be 'Debug'
         $Completions.CompletionMatches[2].CompletionText | Should -Be 'RelWithDebInfo'
@@ -21,7 +21,7 @@ Describe 'BuildConfigurationsCompleter' {
 
     It 'Returns the default configurations when no preset is specified, filtered by the word to complete' {
         $Completions = Get-CommandCompletion "Build-CMakeBuild -Configuration D"
-        $Completions.CompletionMatches.Count | Should -Be 1
+        $Completions.CompletionMatches | Should -HaveCount 1
         $Completions.CompletionMatches[0].CompletionText | Should -Be 'Debug'
     }
 }

--- a/Tests/BuildPresetsCompleter.Tests.ps1
+++ b/Tests/BuildPresetsCompleter.Tests.ps1
@@ -12,14 +12,14 @@ BeforeAll {
 Describe 'BuildPresetsCompleter' {
     It 'Returns the presets from the discovered presets file, in the order that they are defined' {
         $Completions = Get-CommandCompletion "Build-CMakeBuild -Preset "
-        $Completions.CompletionMatches.Count | Should -Be 2
+        $Completions.CompletionMatches | Should -HaveCount 2
         $Completions.CompletionMatches[0].CompletionText | Should -Be 'windows-x64'
         $Completions.CompletionMatches[1].CompletionText | Should -Be 'windows-arm'
     }
 
     It 'Returns the presets from the discovered presets file, filtered by the word to complete' {
         $Completions = Get-CommandCompletion "Build-CMakeBuild -Preset windows-a"
-        $Completions.CompletionMatches.Count | Should -Be 1
+        $Completions.CompletionMatches | Should -HaveCount 1
         $Completions.CompletionMatches[0].CompletionText | Should -Be 'windows-arm'
     }
 }

--- a/Tests/BuildTargetsCompleter.Tests.ps1
+++ b/Tests/BuildTargetsCompleter.Tests.ps1
@@ -20,7 +20,7 @@ Describe 'BuildTargetsCompleter' {
         Using-Location "$PSScriptRoot/ReferenceBuild" {
             $Completions = Get-CommandCompletion "Build-CMakeBuild -Targets "
 
-            $Completions.CompletionMatches.Count | Should -Be 10
+            $Completions.CompletionMatches | Should -HaveCount 10
             $Completions.CompletionMatches.CompletionText | Should -Be @(
                 'A_Library'
                 'B_Library'

--- a/Tests/GetMacroConstants.Tests.ps1
+++ b/Tests/GetMacroConstants.Tests.ps1
@@ -1,0 +1,26 @@
+#Requires -PSEdition Core
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+BeforeAll {
+    . $PSScriptRoot/../PSCMake/Common/CMake.ps1
+}
+
+Describe 'GetMacroConstants' {
+    It 'Returns the correct macro constants' {
+        $HostSystemName = if ($IsWindows) {
+            'Windows'
+        } elseif ($IsMacOS) {
+            'Darwin'
+        } elseif ($IsLinux) {
+            'Linux'
+        } else {
+            Write-Error "Unsupported `${hostSystemName} value."
+        }
+
+        $MacroConstants = GetMacroConstants
+        $MacroConstants['${hostSystemName}'] | Should -Be $HostSystemName
+        $MacroConstants['$vendor{PSCMake}'] | Should -Be 'true'
+    }
+}


### PR DESCRIPTION
Some general cleanup with the tests, and adding a few more tests for GetMacroConstants. This PR also adds `Build\RunTests.ps1` to make the PR, CI and local test execution flow consistent.