### PR TITLE
Add tests for 'Write-CMakeBuild'

### DIFF
--- a/Tests/ReferenceBuild.ps1
+++ b/Tests/ReferenceBuild.ps1
@@ -48,5 +48,6 @@ function GetReferenceBuildProperties() {
     [PSCustomObject]@{
         BinaryDirectory = $BinaryDirectory
         CodeModelFile = Get-CMakeBuildCodeModel $BinaryDirectory
+        SourceDirectory = (Resolve-Path -Path "$PSScriptRoot/ReferenceBuild/").Path
     }
 }

--- a/Tests/TestUtilities.ps1
+++ b/Tests/TestUtilities.ps1
@@ -6,3 +6,25 @@ $ErrorActionPreference = 'Stop'
 function Get-CommandCompletion([string] $InputScript) {
     [System.Management.Automation.CommandCompletion]::CompleteInput($InputScript, $InputScript.Length, $null)
 }
+
+function Zip-Object {
+    $Objects = $args
+
+    if ($Objects.Count -lt 2) {
+        throw "At least two collections must be specified"
+    }
+
+    $First = $Objects[0]
+    $Objects | ForEach-Object {
+        if ($_.Count -ne $First.Count) {
+            throw "All collections must have the same number of elements"
+        }
+    }
+    for ($i = 0; $i -lt $First.Count; $i++) {
+        [array]$Current = @()
+        $Objects | ForEach-Object {
+            $Current += $_[$i]
+        }
+        (, $Current)
+    }
+}

--- a/Tests/Write-CMakeBuild.Tests.ps1
+++ b/Tests/Write-CMakeBuild.Tests.ps1
@@ -5,9 +5,11 @@ $ErrorActionPreference = 'Stop'
 
 BeforeAll {
     . $PSScriptRoot/TestUtilities.ps1
+    . $PSScriptRoot/XmlUtilities.ps1
     . $PSScriptRoot/ReferenceBuild.ps1
 
     $Properties = PrepareReferenceBuild
+    $script:BuildProperties = GetReferenceBuildProperties
 
     $CMake = "$env:ProgramFiles/CMake/bin/cmake.exe"
     & $CMake @Properties
@@ -17,7 +19,7 @@ BeforeAll {
 
 Describe 'Write-CMakeBuild' {
     It 'Writes the build with no parameters' {
-        Using-Location "$PSScriptRoot/ReferenceBuild" {
+        Using-Location $BuildProperties.SourceDirectory {
             $ExpectedDotFile = @'
 digraph CodeModel {
   "A_Library::@6890427a1f51a3e7e1df" [label="A_Library"]
@@ -31,6 +33,21 @@ digraph CodeModel {
 '@
             ((Write-CMakeBuild) -join '') |
                 Should -Be ($ExpectedDotFile -replace '\r\n', '')
+        }
+    }
+    It 'Writes the DGML when specified' {
+        Using-Location $BuildProperties.SourceDirectory {
+            [xml]$ExpectedDgml = Get-Content "$PSScriptRoot/Write-CMakeBuild.dgml"
+            SortChildElements $ExpectedDgml.DirectedGraph.Links { $_.Target }
+
+            [xml]$ActualDgml = Write-CMakeBuild -As Dgml
+            $ActualDgml.DirectedGraph.Nodes.Node |
+                Where-Object { Get-MemberValue $_ Definition } |
+                ForEach-Object { $_.Definition = $_.Definition.Replace($BuildProperties.SourceDirectory, "") }
+            SortChildElements $ActualDgml.DirectedGraph.Links { $_.Target }
+
+            $ActualDgml.OuterXml |
+                Should -Be $ExpectedDgml.OuterXml
         }
     }
 }

--- a/Tests/Write-CMakeBuild.dgml
+++ b/Tests/Write-CMakeBuild.dgml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="utf-8"?>
+<DirectedGraph xmlns="http://schemas.microsoft.com/vs/2009/dgml">
+<Properties>
+<Property Id="Definition" Label="Definition" DataType="System.String" IsReference="True" />
+<Property Id="Type" DataType="System.String" />
+</Properties>
+<Styles>
+<Style TargetType="Node" GroupLabel="Executable" ValueLabel="Executable">
+<Condition Expression="Type='EXECUTABLE'" />
+<Setter Property="Background" Value="#FF0000" />
+</Style>
+</Styles>
+<Nodes>
+<Node
+  Id="A_Library::@6890427a1f51a3e7e1df"
+  Label="A_Library"
+  Type="STATIC_LIBRARY"
+  Definition="CMakeLists.txt"
+/>
+<Node
+  Id="Debug/A_Library.lib"
+/>
+<Node
+  Id="B_Library::@6890427a1f51a3e7e1df"
+  Label="B_Library"
+  Type="STATIC_LIBRARY"
+  Definition="CMakeLists.txt"
+/>
+<Node
+  Id="Debug/B_Library.lib"
+/>
+<Node
+  Id="C_Library::@6890427a1f51a3e7e1df"
+  Label="C_Library"
+  Type="STATIC_LIBRARY"
+  Definition="CMakeLists.txt"
+/>
+<Node
+  Id="Debug/C_Library.lib"
+/>
+<Node
+  Id="SubDirectoryOther_Executable::@01210d55993b56455dd6"
+  Label="SubDirectoryOther_Executable"
+  Type="EXECUTABLE"
+  Definition="SubDirectoryOther\CMakeLists.txt"
+/>
+<Node
+  Id="SubDirectoryOther/Debug/SubDirectoryOther_Executable.exe"
+/>
+<Node
+  Id="SubDirectoryOther/Debug/SubDirectoryOther_Executable.pdb"
+/>
+<Node
+  Id="SubDirectoryOther_Library::@01210d55993b56455dd6"
+  Label="SubDirectoryOther_Library"
+  Type="STATIC_LIBRARY"
+  Definition="SubDirectoryOther\CMakeLists.txt"
+/>
+<Node
+  Id="SubDirectoryOther/Debug/SubDirectoryOther_Library.lib"
+/>
+<Node
+  Id="SubDirectory_Executable::@c68b9f6dab07fa391196"
+  Label="SubDirectory_Executable"
+  Type="EXECUTABLE"
+  Definition="SubDirectory\CMakeLists.txt"
+/>
+<Node
+  Id="SubDirectory/Debug/SubDirectory_Executable.exe"
+/>
+<Node
+  Id="SubDirectory/Debug/SubDirectory_Executable.pdb"
+/>
+<Node
+  Id="SubDirectory_Library::@c68b9f6dab07fa391196"
+  Label="SubDirectory_Library"
+  Type="STATIC_LIBRARY"
+  Definition="SubDirectory\CMakeLists.txt"
+/>
+<Node
+  Id="SubDirectory/Debug/SubDirectory_Library.lib"
+/>
+</Nodes>
+<Links>
+<Link
+  Source="SubDirectory_Executable::@c68b9f6dab07fa391196"
+  Target="SubDirectory/Debug/SubDirectory_Executable.exe"
+/>
+<Link
+  Source="SubDirectory_Executable::@c68b9f6dab07fa391196"
+  Target="SubDirectory/Debug/SubDirectory_Executable.pdb"
+/>
+<Link
+  Source="B_Library::@6890427a1f51a3e7e1df"
+  Target="Debug/B_Library.lib"
+/>
+<Link
+  Source="SubDirectory_Library::@c68b9f6dab07fa391196"
+  Target="SubDirectory/Debug/SubDirectory_Library.lib"
+/>
+<Link
+  Source="SubDirectoryOther_Library::@01210d55993b56455dd6"
+  Target="SubDirectoryOther/Debug/SubDirectoryOther_Library.lib"
+/>
+<Link
+  Source="A_Library::@6890427a1f51a3e7e1df"
+  Target="Debug/A_Library.lib"
+/>
+<Link
+  Source="C_Library::@6890427a1f51a3e7e1df"
+  Target="Debug/C_Library.lib"
+/>
+<Link
+  Source="SubDirectoryOther_Executable::@01210d55993b56455dd6"
+  Target="SubDirectoryOther/Debug/SubDirectoryOther_Executable.exe"
+/>
+<Link
+  Source="SubDirectoryOther_Executable::@01210d55993b56455dd6"
+  Target="SubDirectoryOther/Debug/SubDirectoryOther_Executable.pdb"
+/>
+</Links>
+</DirectedGraph>

--- a/Tests/XmlUtilities.ps1
+++ b/Tests/XmlUtilities.ps1
@@ -1,0 +1,32 @@
+#Requires -PSEdition Core
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$TypeAccelerators = [psobject].Assembly.GetType("System.Management.Automation.TypeAccelerators")
+$TypeAccelerators::Add("xmlelement", [System.Xml.XmlElement])
+
+function RemoveChildElements([xmlelement] $XmlElement) {
+    $ChildNodes = $XmlElement.ChildNodes
+    for ($Index = 0; $Index -lt $ChildNodes.Count; ) {
+        $ChildXmlElement = $ChildNodes.Item($Index)
+        if ($ChildXmlElement.NodeType -eq 'Element') {
+            $XmlElement.RemoveChild($ChildXmlElement)
+        } else {
+            $Index++
+        }
+    }
+}
+
+function AddChildElements([xmlelement]$XmlElement, [array] $ChildElements) {
+    $ChildElements |
+        ForEach-Object {
+            $null = $XmlElement.AppendChild($_)
+        }
+}
+
+function SortChildElements([xmlelement] $LinksElement, [scriptblock] $SortExpression) {
+    $LinkArray = RemoveChildElements $LinksElement
+    $LinkArray = $LinkArray | Sort-Object $SortExpression
+    AddChildElements $LinksElement $LinkArray
+}


### PR DESCRIPTION
Adding some tests for Write-CMakeBuild -As Dgml - ensuring that the ReferenceBuild emits Dgml content that is equal to the reference Dgml for it.