### PR TITLE
Accommodate '[' and ']' in preset names when finding the code model

### DIFF
--- a/PSCMake/Common/CMake.ps1
+++ b/PSCMake/Common/CMake.ps1
@@ -448,7 +448,12 @@ function Get-CMakeBuildCodeModel {
     param(
         [string] $BinaryDirectory
     )
-    Get-ChildItem -Path (Get-CMakeBuildCodeModelDirectory $BinaryDirectory) -File -Filter 'codemodel-v2-*' -ErrorAction SilentlyContinue |
+
+    # Since BinaryDirectory may contain characters that are valid for the file-system, but are used by PowerShell's
+    # wildcard syntax (i.e. '[' and ']'), escape the characters before passing to Get-ChildItem.
+    $EscapedBinaryDirectory = $BinaryDirectory.Replace('[', '`[').Replace(']', '`]')
+
+    Get-ChildItem -Path (Get-CMakeBuildCodeModelDirectory $EscapedBinaryDirectory) -File -Filter 'codemodel-v2-*' -ErrorAction SilentlyContinue |
         Select-Object -First 1 |
         Get-Content |
         ConvertFrom-Json


### PR DESCRIPTION
If a preset name includes `[` or `]`, then `Get-CMakeBuildCodeModel` fails, since it uses the path containing the preset name in a call to `Get-ChildItem`, which allows the path to use PowerShell's wildcard syntax. Since the path itself doesn't need wildcards - `Get-ChildItem` is used for the `'codemodel-v2-*'` filter - then `[` and `]` can be escaped.