### PR TITLE
Better support for presets containing `[` and `]`

### DIFF
--- a/PSCMake/Common/CMake.ps1
+++ b/PSCMake/Common/CMake.ps1
@@ -418,8 +418,8 @@ function FilterExecutableTargets {
     )
     $TargetJsons = $TargetTuplesCodeModel |
         ForEach-Object {
-            Join-Path -Path $CodeModelDirectory -ChildPath $_.jsonFile |
-                Get-Item |
+            $JsonPath = Join-Path -Path $CodeModelDirectory -ChildPath $_.jsonFile
+            Get-Item -LiteralPath $JsonPath |
                 Get-Content |
                 ConvertFrom-Json
             }
@@ -450,10 +450,8 @@ function Get-CMakeBuildCodeModel {
     )
 
     # Since BinaryDirectory may contain characters that are valid for the file-system, but are used by PowerShell's
-    # wildcard syntax (i.e. '[' and ']'), escape the characters before passing to Get-ChildItem.
-    $EscapedBinaryDirectory = $BinaryDirectory.Replace('[', '`[').Replace(']', '`]')
-
-    Get-ChildItem -Path (Get-CMakeBuildCodeModelDirectory $EscapedBinaryDirectory) -File -Filter 'codemodel-v2-*' -ErrorAction SilentlyContinue |
+    # wildcard syntax (i.e. '[' and ']'), specify it as the LiteralPath to Get-ChildItem
+    Get-ChildItem -LiteralPath (Get-CMakeBuildCodeModelDirectory $BinaryDirectory) -File -Filter 'codemodel-v2-*' -ErrorAction SilentlyContinue |
         Select-Object -First 1 |
         Get-Content |
         ConvertFrom-Json

--- a/PSCMake/PSCMake.psm1
+++ b/PSCMake/PSCMake.psm1
@@ -385,8 +385,8 @@ function Build-CMakeBuild {
             #  5) "Get-CMakeBuildCodeModel" returns $null
             if ($Configure -or
                 $Fresh -or
-                (-not (Test-Path -Path $CMakeCacheFile -PathType Leaf)) -or
-                (-not (Test-Path -Path (Get-CMakeBuildCodeModelDirectory $BinaryDirectory) -PathType Container)) -or
+                (-not (Test-Path -LiteralPath $CMakeCacheFile -PathType Leaf)) -or
+                (-not (Test-Path -LiteralPath (Get-CMakeBuildCodeModelDirectory $BinaryDirectory) -PathType Container)) -or
                 (-not ($CodeModel = Get-CMakeBuildCodeModel $BinaryDirectory))
                 ) {
                 ConfigureCMake -CMake $CMake $CMakePresetsJson $ConfigurePreset -Fresh:$Fresh

--- a/Tests/Configure-CMakeBuild.Tests.ps1
+++ b/Tests/Configure-CMakeBuild.Tests.ps1
@@ -80,9 +80,10 @@ Describe 'Configure-CMakeBuild' {
         Using-Location "$PSScriptRoot/ReferenceBuild" {
             Configure-CMakeBuild -Preset windows-*
 
-            $script:CMakeCalls | Should -HaveCount 2
+            $script:CMakeCalls | Should -HaveCount 3
             $script:CMakeCalls[0] | Should -Be @('--preset', 'windows-x64')
-            $script:CMakeCalls[1] | Should -Be @('--preset', 'windows-arm')
+            $script:CMakeCalls[1] | Should -Be @('--preset', 'windows-x64[asan]')
+            $script:CMakeCalls[2] | Should -Be @('--preset', 'windows-arm')
         }
     }
 

--- a/Tests/Invoke-CMakeOutput.Tests.ps1
+++ b/Tests/Invoke-CMakeOutput.Tests.ps1
@@ -7,9 +7,11 @@ BeforeAll {
     . $PSScriptRoot/TestUtilities.ps1
     . $PSScriptRoot/ReferenceBuild.ps1
 
-    $Properties = PrepareReferenceBuild
-
     $CMake = "$env:ProgramFiles/CMake/bin/cmake.exe"
+    $Properties = PrepareReferenceBuild 'windows-x64'
+    & $CMake @Properties
+
+    $Properties = PrepareReferenceBuild 'windows-x64[asan]'
     & $CMake @Properties
 
     Import-Module -Force $PSScriptRoot/../PSCMake/PSCMake.psd1 -DisableNameChecking
@@ -70,6 +72,17 @@ Describe 'Invoke-CMakeOutput' {
             $script:ExecutableCalls[0].Arguments | Should -Be @('--build', '--preset', 'windows-x64', '--target', 'SubDirectory_Executable')
             $script:ExecutableCalls[1].Arguments | Should -BeNullOrEmpty
             $script:ExecutableCalls[1].Path | Should -Be @("$PSScriptRoot\ReferenceBuild\__output\windows-x64\SubDirectory\Debug\SubDirectory_Executable.exe")
+        }
+    }
+
+    It 'Runs an executable in a preset with [ and ]' {
+        Using-Location "$PSScriptRoot/ReferenceBuild/SubDirectory" {
+            Invoke-CMakeOutput -preset 'windows-x64[asan]'
+
+            $script:ExecutableCalls | Should -HaveCount 2
+            $script:ExecutableCalls[0].Arguments | Should -Be @('--build', '--preset', 'windows-x64[asan]', '--target', 'SubDirectory_Executable')
+            $script:ExecutableCalls[1].Arguments | Should -BeNullOrEmpty
+            $script:ExecutableCalls[1].Path | Should -Be @("$PSScriptRoot\ReferenceBuild\__output\windows-x64[asan]\SubDirectory\Debug\SubDirectory_Executable.exe")
         }
     }
 

--- a/Tests/ReferenceBuild.ps1
+++ b/Tests/ReferenceBuild.ps1
@@ -7,7 +7,7 @@ $ErrorActionPreference = 'Stop'
 . $PSScriptRoot/../PSCMake/Common/Ninja.ps1
 
 # Get ninja.exe
-function PrepareReferenceBuild() {
+function PrepareReferenceBuild($Preset = 'windows-x64') {
     $NinjaCommand = Get-Command 'ninja.exe' -ErrorAction SilentlyContinue
     $NinjaPath = if ($NinjaCommand) {
         $NinjaCommand.Source
@@ -25,7 +25,7 @@ function PrepareReferenceBuild() {
         Select-Object -First 1
 
     # Write the CMake query files
-    $BinaryDirectory = New-Item -Path "$PSScriptRoot/ReferenceBuild/__output/windows-x64" -ItemType Directory -Force
+    $BinaryDirectory = New-Item -Path "$PSScriptRoot/ReferenceBuild/__output/$Preset" -ItemType Directory -Force
 
     Enable-CMakeBuildQuery $BinaryDirectory
 
@@ -35,7 +35,7 @@ function PrepareReferenceBuild() {
     $CMAKE_MAKE_PROGRAM = $NinjaPath.Replace('\', '/')
 
     @(
-        "--preset", "windows-x64",
+        "--preset", $Preset,
         "-S", $BuildPath
         "-DCMAKE_CXX_COMPILER=$CMAKE_CXX_COMPILER"
         "-DCMAKE_MAKE_PROGRAM=$CMAKE_MAKE_PROGRAM"

--- a/Tests/ReferenceBuild/CMakePresets.json
+++ b/Tests/ReferenceBuild/CMakePresets.json
@@ -5,7 +5,8 @@
     "minor": 21,
     "patch": 0
   },
-  "configurePresets": [{
+  "configurePresets": [
+    {
       "name": "ninja",
       "hidden": true,
       "generator": "Ninja Multi-Config"
@@ -31,6 +32,13 @@
       "environment": {}
     },
     {
+      "name": "windows-x64[asan]",
+      "inherits": "windows-x64",
+      "cacheVariables": {
+        "ENABLE_ASAN": "ON"
+      }
+    },
+    {
       "name": "windows-arm",
       "inherits": "windows",
       "description": "windows-arm",
@@ -43,24 +51,31 @@
       "environment": {}
     }
   ],
-  "buildPresets": [{
+  "buildPresets": [
+    {
       "name": "windows-x64",
       "configurePreset": "windows-x64"
+    },
+    {
+      "name": "windows-x64[asan]",
+      "configurePreset": "windows-x64[asan]"
     },
     {
       "name": "windows-arm",
       "configurePreset": "windows-arm"
     }
   ],
-  "testPresets": [{
-    "name": "windows-x64",
-    "configurePreset": "windows-x64",
-    "output": {
-      "outputOnFailure": true
-    },
-    "execution": {
-      "noTestsAction": "error",
-      "stopOnFailure": true
+  "testPresets": [
+    {
+      "name": "windows-x64",
+      "configurePreset": "windows-x64",
+      "output": {
+        "outputOnFailure": true
+      },
+      "execution": {
+        "noTestsAction": "error",
+        "stopOnFailure": true
+      }
     }
-  }]
+  ]
 }


### PR DESCRIPTION
`[` and `]` are valid CMake preset name and file-system characters, but in many CmdLet parameters they're interpreted as wildcard characters. As a result, when using `[` and `]` in a preset name - like `windows-x64[asan]`, `Get-Item -Path 'windows-x64[asan]'`will fail, even if a file called `windows-x64[asan]` is present. Instead of using `-Path`, the code should use `-LiteralPath` when not expecting wild-card semantics. This change does that, and adds a test to validate that `Invoke-CMakeOutput` succeeds when a preset with `[` and `]` is used.