### PR TITLE
Consolidate configure- and build- preset code

### DIFF
--- a/PSCMake/Common/CMake.ps1
+++ b/PSCMake/Common/CMake.ps1
@@ -107,9 +107,9 @@ function GetBuildPresetNames {
 
 <#
     .Synopsis
-    Gets names of the 'configurePresets' in the specified CMakePresets.json object.
+    Gets the 'configurePresets' in the specified CMakePresets.json object.
 #>
-function GetConfigurePresetNames {
+function GetConfigurePresets {
     param(
         $CMakePresetsJson
     )
@@ -124,7 +124,7 @@ function GetConfigurePresetNames {
         $Presets = $Presets |
             Where-Object { EvaluatePresetCondition $_ $CMakePresetsJson.configurePresets }
 
-        $Presets.name
+        $Presets
     }
 }
 

--- a/PSCMake/Common/CMake.ps1
+++ b/PSCMake/Common/CMake.ps1
@@ -105,6 +105,29 @@ function GetBuildPresets {
     }
 }
 
+function GetMatchingBuildPresets {
+    param(
+        $CMakePresetsJson,
+        $Preset
+    )
+    $BuildPresets = GetBuildPresets $CMakePresetsJson
+    if (-not $Preset) {
+        if (-not $BuildPresets) {
+            Write-Error "No Presets values specified, and one could not be inferred."
+        }
+        $BuildPresets | Select-Object -First 1
+    } else {
+        foreach ($CandidatePresetName in $Preset) {
+            $MatchingPresets = $BuildPresets |
+                Where-Object { ($_.name -like $CandidatePresetName) -or ($_.name -eq $CandidatePresetName) }
+            if (-not $MatchingPresets) {
+                Write-Error "Unable to find build preset '$CandidatePresetName' in $script:CMakePresetsPath"
+            }
+            $MatchingPresets
+        }
+    }
+}
+
 <#
     .Synopsis
     Gets the 'configurePresets' in the specified CMakePresets.json object.

--- a/PSCMake/Common/CMake.ps1
+++ b/PSCMake/Common/CMake.ps1
@@ -78,9 +78,9 @@ function GetCMakePresets {
 
 <#
     .Synopsis
-    Gets names of the 'buildPresets' in the specified CMakePresets.json object.
+    Gets 'buildPresets' in the specified CMakePresets.json object.
 #>
-function GetBuildPresetNames {
+function GetBuildPresets {
     param(
         $CMakePresetsJson
     )
@@ -101,7 +101,7 @@ function GetBuildPresetNames {
             $null -ne $ConfigurePresetJson
         }
 
-        $Presets.name
+        $Presets
     }
 }
 
@@ -149,26 +149,12 @@ function GetCMake {
     $CMake
 }
 
-function ResolvePresets {
+function GetConfigurePresetFor {
     param(
         $CMakePresetsJson,
-
-        [ValidateSet('buildPresets', 'testPresets')]
-        $PresetType,
-
-        $PresetName
+        $Preset
     )
-    $PresetJson = $CMakePresetsJson.$PresetType | Where-Object { $_.name -eq $PresetName }
-    if (-not $PresetJson) {
-        Write-Error "Unable to find $PresetType '$Preset' in $(GetCMakePresetsPath)"
-    }
-
-    $ConfigurePresetJson = $CMakePresetsJson.configurePresets | Where-Object { $_.name -eq $PresetJson.configurePreset }
-    if (-not $ConfigurePresetJson) {
-        Write-Error "Unable to find configure preset '$($PresetJson.configurePreset)' in $(GetCMakePresetsPath)"
-    }
-
-    $PresetJson, $ConfigurePresetJson
+    $CMakePresetsJson.configurePresets | Where-Object { $_.name -eq $Preset.configurePreset }
 }
 
 <#

--- a/PSCMake/PSCMake.psm1
+++ b/PSCMake/PSCMake.psm1
@@ -63,7 +63,9 @@ function BuildPresetsCompleter {
     $null = $CommandAst
     $null = $FakeBoundParameters
     $CMakePresetsJson = GetCMakePresets -Silent
-    GetBuildPresetNames $CMakePresetsJson | Where-Object { $_ -ilike "$WordToComplete*" }
+    GetBuildPresets $CMakePresetsJson |
+        Select-Object -ExpandProperty 'name' |
+        Where-Object { $_ -ilike "$WordToComplete*" }
 }
 
 <#
@@ -112,10 +114,16 @@ function BuildTargetsCompleter {
     $null = $ParameterName
     $null = $CommandAst
     $CMakePresetsJson = GetCMakePresets -Silent
-    $PresetNames = GetBuildPresetNames $CMakePresetsJson
-    $PresetName = $FakeBoundParameters['Preset'] ?? $PresetNames |
-        Select-Object -First 1
-    $BuildPreset, $ConfigurePreset = ResolvePresets $CMakePresetsJson 'buildPresets' $PresetName
+    $BuildPresets = GetBuildPresets $CMakePresetsJson
+    $BuildPreset = if (-not $FakeBoundParameters['Preset']) {
+        $BuildPresets | Select-Object -First 1
+    } else {
+        $BuildPresets |
+            Where-Object { $_.name -eq $FakeBoundParameters['Preset'] } |
+            Select-Object -First 1
+    }
+
+    $ConfigurePreset = GetConfigurePresetFor $CMakePresetsJson $BuildPreset
     $BinaryDirectory = GetBinaryDirectory $CMakePresetsJson $ConfigurePreset
     $CMakeCodeModel = Get-CMakeBuildCodeModel $BinaryDirectory
 
@@ -159,10 +167,16 @@ function ExecutableTargetsCompleter {
     $null = $ParameterName
     $null = $CommandAst
     $CMakePresetsJson = GetCMakePresets -Silent
-    $PresetNames = GetBuildPresetNames $CMakePresetsJson
-    $PresetName = $FakeBoundParameters['Presets'] ?? $PresetNames |
-        Select-Object -First 1
-    $BuildPreset, $ConfigurePreset = ResolvePresets $CMakePresetsJson 'buildPresets' $PresetName
+    $BuildPresets = GetBuildPresets $CMakePresetsJson
+    $BuildPreset = if (-not $FakeBoundParameters['Preset']) {
+        $BuildPresets | Select-Object -First 1
+    } else {
+        $BuildPresets |
+            Where-Object { $_.name -eq $FakeBoundParameters['Preset'] } |
+            Select-Object -First 1
+    }
+
+    $ConfigurePreset = GetConfigurePresetFor $CMakePresetsJson $BuildPreset
     $BinaryDirectory = GetBinaryDirectory $CMakePresetsJson $ConfigurePreset
     $CMakeCodeModel = Get-CMakeBuildCodeModel $BinaryDirectory
 
@@ -350,16 +364,20 @@ function Build-CMakeBuild {
     )
     $CMakeRoot = FindCMakeRoot
     $CMakePresetsJson = GetCMakePresets
-    $BuildPresetNames = GetBuildPresetNames $CMakePresetsJson
-    $BuildPresetNames = if (-not $Preset) {
-        if (-not $BuildPresetNames) {
+    $BuildPresets = GetBuildPresets $CMakePresetsJson
+    $BuildPresets = if (-not $Preset) {
+        if (-not $BuildPresets) {
             Write-Error "No Presets values specified, and one could not be inferred."
         }
-        $BuildPresetNames | Select-Object -First 1
+        $BuildPresets | Select-Object -First 1
     } else {
-        foreach ($CandidatePreset in $Preset) {
-            $ExpandedPresets = $BuildPresetNames | Where-Object { $_ -like $CandidatePreset }
-            $ExpandedPresets ?? $CandidatePreset
+        foreach ($CandidatePresetName in $Preset) {
+            $MatchingPresets = $BuildPresets |
+                Where-Object { ($_.name -like $CandidatePresetName) -or ($_.name -eq $CandidatePresetName) }
+            if (-not $MatchingPresets) {
+                Write-Error "Unable to find build preset '$CandidatePresetName' in $script:CMakePresetsPath"
+            }
+            $MatchingPresets
         }
     }
 
@@ -371,10 +389,10 @@ function Build-CMakeBuild {
     $ScopeLocation = (Get-Location).Path
     $CMake = GetCMake
     Using-Location $CMakeRoot {
-        foreach ($BuildPresetName in $BuildPresetNames) {
-            Write-Output "Preset         : $BuildPresetName"
+        foreach ($BuildPreset in $BuildPresets) {
+            Write-Output "Preset         : $($BuildPreset.name)"
 
-            $BuildPreset, $ConfigurePreset = ResolvePresets $CMakePresetsJson 'buildPresets' $BuildPresetName
+            $ConfigurePreset = GetConfigurePresetFor $CMakePresetsJson $BuildPreset
             $BinaryDirectory = GetBinaryDirectory $CMakePresetsJson $ConfigurePreset
             $CMakeCacheFile = Join-Path -Path $BinaryDirectory -ChildPath 'CMakeCache.txt'
 
@@ -416,7 +434,7 @@ function Build-CMakeBuild {
 
                 $CMakeArguments = @(
                     '--build'
-                    '--preset', $BuildPresetName
+                    '--preset', $BuildPreset.name
                     if ($ConfigurationName) {
                         '--config', $ConfigurationName
                     }
@@ -452,17 +470,23 @@ function Write-CMakeBuild {
         [string] $As = 'dot'
     )
     $CMakePresetsJson = GetCMakePresets
-    $PresetNames = GetBuildPresetNames $CMakePresetsJson
-
-    if (-not $Preset) {
-        if (-not $PresetNames) {
-            Write-Error "No Preset values specified, and one could not be inferred."
+    $BuildPresets = GetBuildPresets $CMakePresetsJson
+    $BuildPreset = if (-not $Preset) {
+        if (-not $BuildPresets) {
+            Write-Error "No Presets values specified, and one could not be inferred."
         }
-        $Preset = $PresetNames | Select-Object -First 1
-        Write-Information "No preset specified, defaulting to: $Preset"
+        $BuildPresets | Select-Object -First 1
+    } else {
+        $MatchingPreset = $BuildPresets |
+            Where-Object { ($_.name -like $Preset) -or ($_.name -eq $Preset) } |
+            Select-Object -First 1
+        if (-not $MatchingPreset) {
+            Write-Error "Unable to find build preset '$Preset' in $script:CMakePresetsPath"
+        }
+        $MatchingPreset
     }
 
-    $BuildPreset, $ConfigurePreset = ResolvePresets $CMakePresetsJson 'buildPresets' $Preset
+    $ConfigurePreset = GetConfigurePresetFor $CMakePresetsJson $BuildPreset
     $BinaryDirectory = GetBinaryDirectory $CMakePresetsJson $ConfigurePreset
     $CodeModel = Get-CMakeBuildCodeModel $BinaryDirectory
     $CodeModelDirectory = Get-CMakeBuildCodeModelDirectory $BinaryDirectory
@@ -522,16 +546,22 @@ function Invoke-CMakeOutput {
         [string[]] $Arguments
     )
     $CMakePresetsJson = GetCMakePresets
-    $PresetNames = GetBuildPresetNames $CMakePresetsJson
-
-    if (-not $Preset) {
-        if (-not $PresetNames) {
+    $BuildPresets = GetBuildPresets $CMakePresetsJson
+    $BuildPreset = if (-not $Preset) {
+        if (-not $BuildPresets) {
             Write-Error "No Presets values specified, and one could not be inferred."
         }
-        $Preset = $PresetNames | Select-Object -First 1
+        $BuildPresets | Select-Object -First 1
+    } else {
+        $MatchingPreset = $BuildPresets |
+            Where-Object { ($_.name -like $Preset) -or ($_.name -eq $Preset) } |
+            Select-Object -First 1
+        if (-not $MatchingPreset) {
+            Write-Error "Unable to find build preset '$Preset' in $script:CMakePresetsPath"
+        }
+        $MatchingPreset
     }
-
-    $BuildPreset, $ConfigurePreset = ResolvePresets $CMakePresetsJson 'buildPresets' $Preset
+    $ConfigurePreset = GetConfigurePresetFor $CMakePresetsJson $BuildPreset
     $BinaryDirectory = GetBinaryDirectory $CMakePresetsJson $ConfigurePreset
 
     # Find the 'code model' for the preset. If no code model is found, configure the build and try again.

--- a/PSCMake/PSCMake.psm1
+++ b/PSCMake/PSCMake.psm1
@@ -114,15 +114,8 @@ function BuildTargetsCompleter {
     $null = $ParameterName
     $null = $CommandAst
     $CMakePresetsJson = GetCMakePresets -Silent
-    $BuildPresets = GetBuildPresets $CMakePresetsJson
-    $BuildPreset = if (-not $FakeBoundParameters['Preset']) {
-        $BuildPresets | Select-Object -First 1
-    } else {
-        $BuildPresets |
-            Where-Object { $_.name -eq $FakeBoundParameters['Preset'] } |
-            Select-Object -First 1
-    }
-
+    $BuildPreset = GetMatchingBuildPresets $CMakePresetsJson $FakeBoundParameters['Preset'] |
+        Select-Object -First 1
     $ConfigurePreset = GetConfigurePresetFor $CMakePresetsJson $BuildPreset
     $BinaryDirectory = GetBinaryDirectory $CMakePresetsJson $ConfigurePreset
     $CMakeCodeModel = Get-CMakeBuildCodeModel $BinaryDirectory
@@ -167,15 +160,8 @@ function ExecutableTargetsCompleter {
     $null = $ParameterName
     $null = $CommandAst
     $CMakePresetsJson = GetCMakePresets -Silent
-    $BuildPresets = GetBuildPresets $CMakePresetsJson
-    $BuildPreset = if (-not $FakeBoundParameters['Preset']) {
-        $BuildPresets | Select-Object -First 1
-    } else {
-        $BuildPresets |
-            Where-Object { $_.name -eq $FakeBoundParameters['Preset'] } |
-            Select-Object -First 1
-    }
-
+    $BuildPreset = GetMatchingBuildPresets $CMakePresetsJson $FakeBoundParameters['Preset'] |
+        Select-Object -First 1
     $ConfigurePreset = GetConfigurePresetFor $CMakePresetsJson $BuildPreset
     $BinaryDirectory = GetBinaryDirectory $CMakePresetsJson $ConfigurePreset
     $CMakeCodeModel = Get-CMakeBuildCodeModel $BinaryDirectory
@@ -364,22 +350,7 @@ function Build-CMakeBuild {
     )
     $CMakeRoot = FindCMakeRoot
     $CMakePresetsJson = GetCMakePresets
-    $BuildPresets = GetBuildPresets $CMakePresetsJson
-    $BuildPresets = if (-not $Preset) {
-        if (-not $BuildPresets) {
-            Write-Error "No Presets values specified, and one could not be inferred."
-        }
-        $BuildPresets | Select-Object -First 1
-    } else {
-        foreach ($CandidatePresetName in $Preset) {
-            $MatchingPresets = $BuildPresets |
-                Where-Object { ($_.name -like $CandidatePresetName) -or ($_.name -eq $CandidatePresetName) }
-            if (-not $MatchingPresets) {
-                Write-Error "Unable to find build preset '$CandidatePresetName' in $script:CMakePresetsPath"
-            }
-            $MatchingPresets
-        }
-    }
+    $BuildPresets = GetMatchingBuildPresets $CMakePresetsJson $Preset
 
     # If;
     #   * no targets were specified, and
@@ -470,22 +441,8 @@ function Write-CMakeBuild {
         [string] $As = 'dot'
     )
     $CMakePresetsJson = GetCMakePresets
-    $BuildPresets = GetBuildPresets $CMakePresetsJson
-    $BuildPreset = if (-not $Preset) {
-        if (-not $BuildPresets) {
-            Write-Error "No Presets values specified, and one could not be inferred."
-        }
-        $BuildPresets | Select-Object -First 1
-    } else {
-        $MatchingPreset = $BuildPresets |
-            Where-Object { ($_.name -like $Preset) -or ($_.name -eq $Preset) } |
-            Select-Object -First 1
-        if (-not $MatchingPreset) {
-            Write-Error "Unable to find build preset '$Preset' in $script:CMakePresetsPath"
-        }
-        $MatchingPreset
-    }
-
+    $BuildPreset = GetMatchingBuildPresets $CMakePresetsJson $Preset |
+        Select-Object -First 1
     $ConfigurePreset = GetConfigurePresetFor $CMakePresetsJson $BuildPreset
     $BinaryDirectory = GetBinaryDirectory $CMakePresetsJson $ConfigurePreset
     $CodeModel = Get-CMakeBuildCodeModel $BinaryDirectory
@@ -546,21 +503,8 @@ function Invoke-CMakeOutput {
         [string[]] $Arguments
     )
     $CMakePresetsJson = GetCMakePresets
-    $BuildPresets = GetBuildPresets $CMakePresetsJson
-    $BuildPreset = if (-not $Preset) {
-        if (-not $BuildPresets) {
-            Write-Error "No Presets values specified, and one could not be inferred."
-        }
-        $BuildPresets | Select-Object -First 1
-    } else {
-        $MatchingPreset = $BuildPresets |
-            Where-Object { ($_.name -like $Preset) -or ($_.name -eq $Preset) } |
-            Select-Object -First 1
-        if (-not $MatchingPreset) {
-            Write-Error "Unable to find build preset '$Preset' in $script:CMakePresetsPath"
-        }
-        $MatchingPreset
-    }
+    $BuildPreset = GetMatchingBuildPresets $CMakePresetsJson $Preset |
+        Select-Object -First 1
     $ConfigurePreset = GetConfigurePresetFor $CMakePresetsJson $BuildPreset
     $BinaryDirectory = GetBinaryDirectory $CMakePresetsJson $ConfigurePreset
 

--- a/PSCMake/PSCMake.psm1
+++ b/PSCMake/PSCMake.psm1
@@ -197,7 +197,9 @@ function ConfigurePresetsCompleter {
     $null = $CommandAst
     $null = $FakeBoundParameters
     $CMakePresetsJson = GetCMakePresets -Silent
-    GetConfigurePresetNames $CMakePresetsJson | Where-Object { $_ -ilike "$WordToComplete*" }
+    GetConfigurePresets $CMakePresetsJson |
+        Select-Object -ExpandProperty 'name' |
+        Where-Object { $_ -ilike "$WordToComplete*" }
 }
 
 function ConfigureCMake {
@@ -262,25 +264,24 @@ function Configure-CMakeBuild {
     )
     $CMakeRoot = FindCMakeRoot
     $CMakePresetsJson = GetCMakePresets
-    $ConfigurePresetNames = GetConfigurePresetNames $CMakePresetsJson
-    $ConfigurePresetNames = if (-not $Preset) {
-        $ConfigurePresetNames | Select-Object -First 1
+    $ConfigurePresets = GetConfigurePresets $CMakePresetsJson
+    $ConfigurePresets = if (-not $Preset) {
+        $ConfigurePresets | Select-Object -First 1
     } else {
-        foreach ($CandidatePreset in $Preset) {
-            $ExpandedPresets = $ConfigurePresetNames | Where-Object { $_ -like $CandidatePreset }
-            $ExpandedPresets ?? $CandidatePreset
+        foreach ($CandidatePresetName in $Preset) {
+            $MatchingPresets = $ConfigurePresets |
+                Where-Object { ($_.name -like $CandidatePresetName) -or ($_.name -eq $CandidatePresetName) }
+            if (-not $MatchingPresets) {
+                Write-Error "Unable to find configuration preset '$CandidatePresetName' in $script:CMakePresetsPath"
+            }
+            $MatchingPresets
         }
     }
 
     $CMake = GetCMake
     Using-Location $CMakeRoot {
-        foreach ($ConfigurePresetName in $ConfigurePresetNames) {
-            Write-Output "Preset         : $ConfigurePresetName"
-
-            $ConfigurePreset = $CMakePresetsJson.configurePresets | Where-Object { $_.name -eq $ConfigurePresetName }
-            if (-not $ConfigurePreset) {
-                Write-Error "Unable to find configuration preset '$ConfigurePresetName' in $script:CMakePresetsPath"
-            }
+        foreach ($ConfigurePreset in $ConfigurePresets) {
+            Write-Output "Preset         : $($ConfigurePreset.name)"
 
             ConfigureCMake -CMake $CMake $CMakePresetsJson $ConfigurePreset -Fresh:$Fresh
         }

--- a/Tests/GetConfigurePresets.Tests.ps1
+++ b/Tests/GetConfigurePresets.Tests.ps1
@@ -9,11 +9,12 @@ BeforeAll {
         } }
 }
 
-Describe 'GetConfigurePresetNames' {
+Describe 'GetConfigurePresets' {
     It 'Given CMakePresets.Complex.json it retrieves the correct configuration preset names.' {
         $CMakePresetsJson = Get-Content "$PSScriptRoot/ReferencePresets/CMakePresets.Complex.json" | ConvertFrom-Json
 
-        GetConfigurePresetNames $CMakePresetsJson |
+        GetConfigurePresets $CMakePresetsJson |
+            Select-Object -ExpandProperty 'name' |
             Should -Be @('linux-x64')
     }
 }


### PR DESCRIPTION
Many paths in PSCMake need to find a build- or configuration- preset. The code accepts a preset name through CmdLet parameters, asks for the names of possible presets, matches against the preset name that was passed, and - having resolved a preset - resolves the preset object it needs. This 'two pass' lookup is more work - to be able to support 'user presets' or 'included presets', it would make more sense to consolidate the lookup so the full suite of presets is resolved in one place. And that's what this PR does - getting the full presets up-front. There are individual commits switching 'configure presets' and then 'build presets', and then consolidation of common code.