### PR TITLE
Inital support for CMakeUserPresets.json and including other presets

### DIFF
--- a/PSCMake/Common/CMake.ps1
+++ b/PSCMake/Common/CMake.ps1
@@ -39,18 +39,28 @@ $CMakeCandidates = @(
 
 <#
     .Synopsis
-    Finds the root of the CMake build - the current or ancestral folder containing a 'CMakePresets.json' file.
+    Finds the path of the CMakePresets file in the current or ancestral folder. This may be a 'CMakePresets.json' file
+    or a 'CMakeUserPresets.json' file.
+#>
+function FindCMakePresets {
+    $CurrentLocation = (Get-Location).Path
+    GetPathOfFileAbove $CurrentLocation 'CMakeUserPresets.json', 'CMakePresets.json'
+}
+
+<#
+    .Synopsis
+    Finds the root of the CMake build - the current or ancestral folder containing CMake presets.
 #>
 function FindCMakeRoot {
-    $CurrentLocation = (Get-Location).Path
-    GetPathOfFileAbove $CurrentLocation 'CMakePresets.json'
+    $CMakePresetsPath = FindCMakePresets
+    [System.IO.Path]::GetDirectoryName($CMakePresetsPath)
 }
 
 $script:CMakePresetsPath = $null
 
 <#
     .Synopsis
-    Gets the path that the most recently loaded CMakePresets.json was loaded from.
+    Gets the path that the most recently loaded 'CMakePresets.json' or 'CMakeUserPresets.json' was loaded from.
 #>
 function GetCMakePresetsPath {
     $script:CMakePresetsPath
@@ -64,16 +74,62 @@ function GetCMakePresets {
     param(
         [switch] $Silent
     )
-    $CMakeRoot = FindCMakeRoot
-    if (-not $CMakeRoot) {
+    $script:CMakePresetsPath = FindCMakePresets
+    if (-not $script:CMakePresetsPath) {
         if ($Silent) {
             return $null
         }
-        Write-Error "Can't find CMakePresets.json"
+        Write-Error "Can't find 'CMakePresets.json' or 'CMakeUserPresets.json' in the current or any parent folder."
     }
-    $script:CMakePresetsPath = Join-Path -Path $CMakeRoot -ChildPath 'CMakePresets.json'
-    Write-Verbose "Presets = $CMakePresetsPath"
-    Get-Content $CMakePresetsPath | ConvertFrom-Json
+
+    $CMakeRoot = [System.IO.Path]::GetDirectoryName($CMakePresetsPath)
+    $CMakePresetsJson = $null
+
+    Write-Verbose "Presets = $CMakeRoot"
+
+    # If files were included, load them now and merge them in. Keep track of files that were included to avoid cycles.
+    $IncludedFiles = [System.Collections.Generic.HashSet[string]]::new()
+    [array] $IncludePaths = @(
+        $CMakePresetsPath
+        if ([System.IO.Path]::GetFileName($CMakePresetsPath) -ieq 'CMakeUserPresets.json') {
+            Join-Path -Path $CMakeRoot -ChildPath 'CMakePresets.json'
+        }
+    )
+
+    for (; ; ) {
+        $IncludePath, $IncludePaths = $IncludePaths
+        if (-not $IncludePath) {
+            break
+        }
+
+        Write-Verbose "Processing CMakePresets: $IncludePath"
+
+        # Macro substiution for include paths
+        $IncludePath = MacroReplacement $IncludePath $null
+
+        if (-not (Test-Path -Path $IncludePath -PathType Leaf)) {
+            Write-Error "Included CMake presets file '$IncludePath' not found."
+        }
+
+        if ($IncludedFiles.Contains($IncludePath)) {
+            Write-Error "Cyclic include detected for included CMake presets file '$IncludePath'."
+        }
+
+        $IncludeJson = Get-Content $IncludePath | ConvertFrom-Json
+        if (-not $CMakePresetsJson) {
+            $CMakePresetsJson = $IncludeJson
+        } else {
+            $CMakePresetsJson.buildPresets += Get-MemberValue -InputObject $IncludeJson -Name 'buildPresets' -Or @()
+            $CMakePresetsJson.configurePresets += Get-MemberValue -InputObject $IncludeJson -Name 'configurePresets' -Or @()
+        }
+
+        $IncludePaths += Get-MemberValue -InputObject $IncludeJson -Name 'include' -Or @()
+
+        # Add to included files set
+        $IncludedFiles.Add($IncludePath) | Out-Null
+    }
+
+    $CMakePresetsJson
 }
 
 <#
@@ -363,7 +419,9 @@ function MacroReplacement {
                 break
             }
             '\$\{presetName\}' {
-                $PresetJson.name
+                if ($PresetJson) {
+                    $PresetJson.name
+                }
                 break
             }
             '\$\{generator\}' {

--- a/PSCMake/Common/Common.ps1
+++ b/PSCMake/Common/Common.ps1
@@ -97,13 +97,19 @@ function DownloadFile([string] $Url, [string] $DownloadPath) {
 
 <#
     .Synopsis
-    Searches the given location and parent folders looking for the given file.
+    Searches the given location and parent folders looking for the given file(s).
+
+    .Outputs
+    The path to the first matching file found, or $null if none found.
 #>
-function GetPathOfFileAbove([string]$Location, [string]$File) {
+function GetPathOfFileAbove([string]$Location, [string[]]$Files) {
     for (; $Location.Length -ne 0; $Location = Split-Path $Location) {
-        if (Test-Path -PathType Leaf -Path (Join-Path -Path $Location -ChildPath $File)) {
-            $Location
-            break
+        foreach ($File in $Files) {
+            $Candidate = Join-Path -Path $Location -ChildPath $File
+            if (Test-Path -PathType Leaf -Path $Candidate) {
+                $Candidate
+                break
+            }
         }
     }
 }

--- a/Tests/GetCMakePresets.Tests.ps1
+++ b/Tests/GetCMakePresets.Tests.ps1
@@ -6,8 +6,8 @@ BeforeAll {
 
 Describe 'GetCMakePresets' {
     It 'Loads the CMakePresets.json when running from a folder with a CMakePresets.json' {
-        Mock FindCMakeRoot {
-            Join-Path -Path $PSScriptRoot -ChildPath 'ReferenceBuild'
+        Mock FindCMakePresets {
+            Join-Path -Path $PSScriptRoot -ChildPath 'ReferenceBuild/CMakePresets.json'
         }
 
         $ActualCMakePresetsJson = GetCMakePresets
@@ -20,7 +20,7 @@ Describe 'GetCMakePresets' {
     }
 
     It 'Reports an error when a CMakePresets.json is not found' {
-        Mock FindCMakeRoot {
+        Mock FindCMakePresets {
             $null
         }
         { GetCMakePresets } |
@@ -28,7 +28,7 @@ Describe 'GetCMakePresets' {
     }
 
     It 'Reports an error when a CMakePresets.json is not found, unless -Silent is passed' {
-        Mock FindCMakeRoot {
+        Mock FindCMakePresets {
             $null
         }
         GetCMakePresets -Silent |


### PR DESCRIPTION
Fixes #1 and #49.

This PR adds support for `CMakeUserPresets.json` and including other presets. The two are somewhat intertwined - `CMakeUserPresets.json` implicitly includes `CMakePresets.json` - so I'm sending the PR for both. #81 laid the groundwork for this change - all paths that load presets go through a common `GetCMakePresets` path, and that can be responsible for resolving and merging the includes. Whilst merging is slightly more up-front work than I'd like - compared to, say, maintaining a list of loaded presets - caching the merged version sounds interesting... But I'll ponder the two approaches...

The changes:
1. `FindCMakePresets`, `FindCMakePresets`, `GetPathOfFileAbove` changes are necessary to support `CMakeUserPresets.json` - the crux of which is `GetPathOfFileAbove` accommodating multiple files and checking them _in order_ - a CMakeUserPresets.json should be preferred over CMakePresets.json
2. `GetCMakePresets` is the support for 'includes' - it performs a breadth-first traversal of the presets .json, and accumulates the presets on the first instance found.

By making sure that `CMakeUserPresets.json` is preferred over `CMakePresets.json`, and that included presets are added to the _end_ of existing presets, then the `CMakeUserPresets.json` presets will be discovered first when presets aren't passed to, say, `Build-CMakeBuild` or `Configure-CMake` build, and are included first in the tab-completion order.

I haven't really thought too much about testing right now... Mocking out the file system seems like a good amount of work, and building reference presets sounds like a good amount of work. But getting this checked-in gets this into the Beta builds, and I'll try things out there.