### PR TITLE
Preset includes should be loaded relative to the include'ing file

### DIFF
--- a/PSCMake/Common/CMake.ps1
+++ b/PSCMake/Common/CMake.ps1
@@ -104,17 +104,6 @@ function GetCMakePresets {
 
         Write-Verbose "Processing CMakePresets: $IncludePath"
 
-        # Macro substiution for include paths
-        $IncludePath = MacroReplacement $IncludePath $null
-
-        if (-not (Test-Path -Path $IncludePath -PathType Leaf)) {
-            Write-Error "Included CMake presets file '$IncludePath' not found."
-        }
-
-        if ($IncludedFiles.Contains($IncludePath)) {
-            Write-Error "Cyclic include detected for included CMake presets file '$IncludePath'."
-        }
-
         $IncludeJson = Get-Content $IncludePath | ConvertFrom-Json
         if (-not $CMakePresetsJson) {
             $CMakePresetsJson = $IncludeJson
@@ -123,10 +112,27 @@ function GetCMakePresets {
             $CMakePresetsJson.configurePresets += Get-MemberValue -InputObject $IncludeJson -Name 'configurePresets' -Or @()
         }
 
-        $IncludePaths += Get-MemberValue -InputObject $IncludeJson -Name 'include' -Or @()
+        $NestedIncludePaths = Get-MemberValue -InputObject $IncludeJson -Name 'include' -Or @()
+        $IncludeRoot = [System.IO.Path]::GetDirectoryName($IncludePath)
+        foreach ($NestedIncludePath in $NestedIncludePaths) {
+            # Macro substiution for include paths
+            $NestedIncludePath = MacroReplacement $NestedIncludePath $null
 
-        # Add to included files set
-        $IncludedFiles.Add($IncludePath) | Out-Null
+            if (-not [System.IO.Path]::IsPathFullyQualified($NestedIncludePath)) {
+                $NestedIncludePath = Join-Path -Path $IncludeRoot -ChildPath $NestedIncludePath
+            }
+
+            if (-not (Test-Path -Path $NestedIncludePath -PathType Leaf)) {
+                Write-Error "Included CMake presets file '$NestedIncludePath' not found."
+            }
+
+            if ($IncludedFiles.Contains($NestedIncludePath)) {
+                Write-Error "Cyclic include detected for included CMake presets file '$NestedIncludePath'."
+            }
+
+            $IncludedFiles.Add($NestedIncludePath) | Out-Null
+            $IncludePaths = $NestedIncludePath
+        }
     }
 
     $CMakePresetsJson


### PR DESCRIPTION
Fixes #86.

When loading 'include' presets, relative paths should be loaded relative to the include'ing file. This manifests when building with a CMakePresets.json with includes, but building from a sub-folder - the include is - incorrectly - resolved relative to the sub-folder.

The fix reshuffles a little. There already was validation that the included file was present, but that happened when processing the include, not when loading the include from the file. In order to have the root folder to load from, work to resolve and validate the include is performed when loading from the file.