### PR TITLE
GetScopedTargets should use the 'source' - not the 'build' - folder to scope targets

### DIFF
--- a/PSCMake/Common/CMake.ps1
+++ b/PSCMake/Common/CMake.ps1
@@ -579,7 +579,7 @@ function GetScopedTargets {
     $SourceDir = $CodeModel.paths.source
     $CodeModelConfiguration.targets |
         Where-Object {
-            $Folder = $CodeModelConfiguration.directories[$_.directoryIndex].build
+            $Folder = $CodeModelConfiguration.directories[$_.directoryIndex].source
             $Folder = if ($Folder -eq '.') {
                 $SourceDir
             } else {


### PR DESCRIPTION
Fixes #88 

GetScopedTargets uses the 'build' folder - not the 'source' folder - to scope the targets. In the default case, these are the same, but when the two differ GetScopedTargets can fail, preventing building within a sub-folder.