### PR TITLE
Fix consistency with CMake inherited condition evaluation

### DIFF
--- a/PSCMake/Common/CMake.ps1
+++ b/PSCMake/Common/CMake.ps1
@@ -313,22 +313,29 @@ function ResolvePresetProperty {
 
 <#
     .Synopsis
-    Returns $true if the preset (and all its ancestors) have conditions that evaluate to $true, $false otherwise.
+    Walks the preset inheritance chain to find the first ancestor that defines a 'condition' property, evaluates it, and returns the result. If no condition is found, returns $true.
 #>
 function EvaluatePresetCondition {
     param(
         $Preset,
         $Presets
     )
-    $Result = SearchAncestors -Preset $Preset -Presets $Presets {
+    $Scope = @{ Result = $null }
+    SearchAncestors -Preset $Preset -Presets $Presets {
         param($CurrentPreset)
-        $PresetConditionJson = Get-MemberValue $CurrentPreset 'condition'
-        if (($PresetConditionJson) -and
-            (-not (EvaluateCondition $PresetConditionJson $CurrentPreset))) {
-            return $false
+        $ConditionJson = Get-MemberValue $CurrentPreset 'condition'
+        if ($ConditionJson) {
+            if ($null -eq $Scope.Result) {
+                $Scope.Result = EvaluateCondition $ConditionJson $CurrentPreset
+            } else {
+                Write-Verbose "Preset '$($Preset.name)': condition on '$($CurrentPreset.name)' ignored (not the first condition in the inheritance chain)."
+            }
         }
     }
-    $Result -ne $false
+    if ($null -eq $Scope.Result) {
+        return $true
+    }
+    $Scope.Result
 }
 
 <#

--- a/Tests/EvaluatePresetCondition.Tests.ps1
+++ b/Tests/EvaluatePresetCondition.Tests.ps1
@@ -1,0 +1,60 @@
+#Requires -PSEdition Core
+
+BeforeAll {
+    $script:Presets = ConvertFrom-Json -InputObject @'
+[
+    { "name": "TrueBase",  "hidden": true, "condition": { "type": "equals", "lhs": "${hostSystemName}", "rhs": "Linux" } },
+    { "name": "FalseBase", "hidden": true, "condition": { "type": "equals", "lhs": "${hostSystemName}", "rhs": "Windows" } },
+    { "name": "InheritsTrueFirst",  "inherits": [ "TrueBase", "FalseBase" ] },
+    { "name": "InheritsFalseFirst", "inherits": [ "FalseBase", "TrueBase" ] },
+    { "name": "InheritsTrueOnly",   "inherits": "TrueBase" },
+    { "name": "InheritsFalseOnly",  "inherits": "FalseBase" },
+    { "name": "OwnTrue",  "condition": { "type": "equals", "lhs": "${hostSystemName}", "rhs": "Linux" } },
+    { "name": "OwnFalse", "condition": { "type": "equals", "lhs": "${hostSystemName}", "rhs": "Windows" } },
+    { "name": "NoCondition" }
+]
+'@
+
+    . $PSScriptRoot/../PSCMake/Common/CMake.ps1
+
+    Mock GetMacroConstants { @{
+            '${hostSystemName}' = 'Linux'
+        } }
+}
+
+Describe 'EvaluatePresetCondition' {
+    It 'Returns $true for a preset with no condition and no inherits' {
+        EvaluatePresetCondition ($script:Presets | Where-Object { $_.name -eq 'NoCondition' } | Select-Object -First 1) $script:Presets |
+            Should -Be $true
+    }
+
+    It 'Returns $true for a preset whose own condition evaluates to $true' {
+        EvaluatePresetCondition ($script:Presets | Where-Object { $_.name -eq 'OwnTrue' } | Select-Object -First 1) $script:Presets |
+            Should -Be $true
+    }
+
+    It 'Returns $false for a preset whose own condition evaluates to $false' {
+        EvaluatePresetCondition ($script:Presets | Where-Object { $_.name -eq 'OwnFalse' } | Select-Object -First 1) $script:Presets |
+            Should -Be $false
+    }
+
+    It 'Returns $true when the only inherited condition evaluates to $true' {
+        EvaluatePresetCondition ($script:Presets | Where-Object { $_.name -eq 'InheritsTrueOnly' } | Select-Object -First 1) $script:Presets |
+            Should -Be $true
+    }
+
+    It 'Returns $false when the only inherited condition evaluates to $false' {
+        EvaluatePresetCondition ($script:Presets | Where-Object { $_.name -eq 'InheritsFalseOnly' } | Select-Object -First 1) $script:Presets |
+            Should -Be $false
+    }
+
+    It 'Returns $true when the first inherited condition is $true even if a later inherited condition is $false' {
+        EvaluatePresetCondition ($script:Presets | Where-Object { $_.name -eq 'InheritsTrueFirst' } | Select-Object -First 1) $script:Presets |
+            Should -Be $true
+    }
+
+    It 'Returns $false when the first inherited condition is $false even if a later inherited condition is $true' {
+        EvaluatePresetCondition ($script:Presets | Where-Object { $_.name -eq 'InheritsFalseFirst' } | Select-Object -First 1) $script:Presets |
+            Should -Be $false
+    }
+}


### PR DESCRIPTION
Fixes #93

Re-implements `EvaluatePresetCondition` to follow the same implementation as CMake, with tests to both document and validate behavior.