### PR TITLE
Support -Arguments to Configure-CMakeBuild, Build-CMakeBuild

### DIFF
--- a/PSCMake/PSCMake.psm1
+++ b/PSCMake/PSCMake.psm1
@@ -219,7 +219,9 @@ function ConfigureCMake {
         [Parameter()]
         $ConfigurePreset,
 
-        [switch] $Fresh
+        [switch] $Fresh,
+
+        [string[]] $Arguments = @()
     )
     $BinaryDirectory = GetBinaryDirectory $CMakePresetsJson $ConfigurePreset
     Enable-CMakeBuildQuery $BinaryDirectory
@@ -232,6 +234,7 @@ function ConfigureCMake {
         if ($VerbosePreference) {
             '--log-level=VERBOSE'
         }
+        $Arguments
     )
 
     InvokeExecutable $CMake $CMakeArguments
@@ -253,6 +256,9 @@ function ConfigureCMake {
     .Parameter Fresh
     A switch specifying whether a 'fresh' configuration is performed - removing any existing cache.
 
+    .Parameter Arguments
+    Additional arguments passed directly to the CMake configure invocation.
+
     .Example
     # Configure the 'windows-x64' and 'windows-x86' CMake builds.
     Configure-CMakeBuild -Preset windows-x64,windows-x86
@@ -266,7 +272,10 @@ function Configure-CMakeBuild {
         [string[]] $Preset,
 
         [Parameter()]
-        [switch] $Fresh
+        [switch] $Fresh,
+
+        [Parameter()]
+        [string[]] $Arguments = @()
     )
     $CMakeRoot = FindCMakeRoot
     $CMakePresetsJson = GetCMakePresets
@@ -289,7 +298,7 @@ function Configure-CMakeBuild {
         foreach ($ConfigurePreset in $ConfigurePresets) {
             Write-Output "Preset         : $($ConfigurePreset.name)"
 
-            ConfigureCMake -CMake $CMake $CMakePresetsJson $ConfigurePreset -Fresh:$Fresh
+            ConfigureCMake -CMake $CMake $CMakePresetsJson $ConfigurePreset -Fresh:$Fresh -Arguments:$Arguments
         }
     }
 }
@@ -320,6 +329,9 @@ function Configure-CMakeBuild {
 
     .Parameter Fresh
     A switch specifying whether a 'fresh' configuration should be performed before the build is run.
+
+    .Parameter Arguments
+    Additional arguments passed directly to the CMake build invocation.
 
     .Example
     # Build the 'windows-x64' and 'windows-x86' CMake builds.
@@ -356,11 +368,16 @@ function Build-CMakeBuild {
         [switch] $Report,
 
         [Parameter()]
-        [switch] $Fresh
+        [switch] $Fresh,
+
+        [Parameter()]
+        [string[]] $Arguments = @()
     )
     $CMakeRoot = FindCMakeRoot
     $CMakePresetsJson = GetCMakePresets
     $BuildPresets = GetMatchingBuildPresets $CMakePresetsJson $Preset
+
+    Write-Verbose "Arguments: $Arguments"
 
     # If;
     #   * no targets were specified, and
@@ -424,6 +441,10 @@ function Build-CMakeBuild {
                         $TargetNames
                     }
                 )
+
+                # Add extra arguments to the CMake build invocation.
+                $CMakeArguments += $Arguments
+                Write-Verbose "CMake Arguments: $CMakeArguments"
 
                 $StartTime = [datetime]::Now
                 InvokeExecutable $CMake $CMakeArguments

--- a/Tests/Build-CMakeBuild.Tests.ps1
+++ b/Tests/Build-CMakeBuild.Tests.ps1
@@ -115,4 +115,42 @@ Describe 'Build-CMakeBuild' {
         $CMakeCalls | Should -HaveCount 1
         $script:CMakeCalls[0] | Should -Be @('--build', '--preset', 'windows-x64', '--target', 'SubDirectory_Executable', 'SubDirectory_Library')
     }
+
+    It 'Passes a single extra argument to CMake' {
+        Using-Location "$PSScriptRoot/ReferenceBuild" {
+            Build-CMakeBuild -Preset windows-x64 -Arguments '--parallel'
+        }
+
+        $script:CMakeCalls | Should -HaveCount 1
+        $script:CMakeCalls[0] | Should -Be @('--build', '--preset', 'windows-x64', '--parallel')
+    }
+
+    It 'Passes multiple extra arguments to CMake' {
+        Using-Location "$PSScriptRoot/ReferenceBuild" {
+            Build-CMakeBuild -Preset windows-x64 -Arguments '--parallel', '8'
+        }
+
+        $script:CMakeCalls | Should -HaveCount 1
+        $script:CMakeCalls[0] | Should -Be @('--build', '--preset', 'windows-x64', '--parallel', '8')
+    }
+
+    It 'Passes extra arguments after other build arguments' {
+        Using-Location "$PSScriptRoot/ReferenceBuild" {
+            Build-CMakeBuild -Preset windows-x64 -Target B_Library -Arguments '--parallel'
+        }
+
+        $script:CMakeCalls | Should -HaveCount 1
+        $script:CMakeCalls[0] | Should -Be @('--build', '--preset', 'windows-x64', '--target', 'B_Library', '--parallel')
+    }
+
+    It 'Passes extra arguments to the build step only when -Fresh is specified' {
+        Using-Location "$PSScriptRoot/ReferenceBuild" {
+            Build-CMakeBuild -Preset windows-x64 -Fresh -Arguments '--parallel'
+        }
+
+        $script:CMakeCalls | Should -HaveCount 2
+        $script:CMakeCalls[0] | Should -Be @('--preset', 'windows-x64', '--fresh')
+        $script:CMakeCalls[1] | Should -Be @('--build', '--preset', 'windows-x64', '--parallel')
+    }
+
 }

--- a/Tests/Configure-CMakeBuild.Tests.ps1
+++ b/Tests/Configure-CMakeBuild.Tests.ps1
@@ -93,4 +93,23 @@ Describe 'Configure-CMakeBuild' {
                 Should -Throw "Unable to find configuration preset 'linux-x64' in $PSScriptRoot\ReferenceBuild\CMakePresets.json"
         }
     }
+
+    It 'Passes a single extra argument to CMake' {
+        Using-Location "$PSScriptRoot/ReferenceBuild" {
+            Configure-CMakeBuild -Arguments '-Wno-dev'
+
+            $script:CMakeCalls | Should -HaveCount 1
+            $script:CMakeCalls[0] | Should -Be @('--preset', 'windows-x64', '-Wno-dev')
+        }
+    }
+
+    It 'Passes multiple extra arguments to CMake' {
+        Using-Location "$PSScriptRoot/ReferenceBuild" {
+            Configure-CMakeBuild -Arguments '-Wno-dev', '-DFOO=BAR'
+
+            $script:CMakeCalls | Should -HaveCount 1
+            $script:CMakeCalls[0] | Should -Be @('--preset', 'windows-x64', '-Wno-dev', '-DFOO=BAR')
+        }
+    }
+
 }


### PR DESCRIPTION
This PR adds `[string[]] $Arguments = @()` to `Build-CMakeBuild` and `Configure-CMakeBuild`, to pass extra parameters to 'cmake.exe' underneath the respective commands.