### PR TITLE
Add Get-CMakeIncludes

### DIFF
--- a/PSCMake/Common/CMake.ps1
+++ b/PSCMake/Common/CMake.ps1
@@ -641,6 +641,25 @@ function GetScopedTargets {
 
 <#
     .Synopsis
+    Gets the value of a CMake cache entry.
+#>
+function GetCacheValue {
+    param(
+        [string] $BinaryDirectory,
+        [string] $CacheEntryName
+    )
+    $CMakeCacheFile = Join-Path -Path $BinaryDirectory -ChildPath 'CMakeCache.txt'
+    if (Test-Path -LiteralPath $CMakeCacheFile) {
+        Get-Content -LiteralPath $CMakeCacheFile |
+            Select-String "^$($CacheEntryName):.*=" |
+            ForEach-Object {
+                $_.ToString().Split('=', 2) | Select-Object -Last 1
+        }
+    }
+}
+
+<#
+    .Synopsis
     Writes the CMake target dependency graph in Graphviz DOT format to the pipeline.
 #>
 function WriteDot {

--- a/PSCMake/Common/Includes.ps1
+++ b/PSCMake/Common/Includes.ps1
@@ -1,0 +1,152 @@
+#----------------------------------------------------------------------------------------------------------------------
+# MIT License
+#
+# Copyright (c) 2025 Mark Schofield
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#----------------------------------------------------------------------------------------------------------------------
+#Requires -PSEdition Core
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+<#
+    .Synopsis
+    Invokes the compiler and returns combined stdout+stderr as an array of strings.
+
+    .Description
+    A function wrapping the compiler invocation, allowing it to be mocked for testing.
+#>
+function InvokeCompilerForIncludes {
+    param(
+        [string] $Path,
+        [string[]] $Arguments
+    )
+    & $Path @Arguments 2>&1 | ForEach-Object { "$_" }
+}
+
+<#
+    .Synopsis
+    Reads the toolchains-v1 File API reply for the given binary directory.
+#>
+function Get-CMakeBuildToolchains {
+    param(
+        [string] $BinaryDirectory
+    )
+    Get-ChildItem -LiteralPath (Get-CMakeBuildCodeModelDirectory $BinaryDirectory) -File -Filter 'toolchains-v1-*' -ErrorAction SilentlyContinue |
+        Select-Object -First 1 |
+        Get-Content |
+        ConvertFrom-Json
+}
+
+<#
+    .Synopsis
+    Searches all targets in the given code model configuration for the named source file and returns its compile
+    group information.
+
+    .Outputs
+    A PSCustomObject with Language, Fragments, Includes, Defines, and BuildDir properties, or $null if not found.
+#>
+function GetCompileInfoForSource {
+    param(
+        $CodeModel,
+        [string] $BinaryDirectory,
+        [string] $Configuration,
+        [string] $SourceFilePath
+    )
+    $ReplyDir = Get-CMakeBuildCodeModelDirectory $BinaryDirectory
+    $SourceDir = $CodeModel.paths.source
+
+    $CodeModelConfig = if ($Configuration) {
+        $CodeModel.configurations | Where-Object { $_.name -eq $Configuration }
+    } else {
+        $CodeModel.configurations[0]
+    }
+
+    foreach ($TargetRef in $CodeModelConfig.targets) {
+        $TargetJson = Get-Content (Join-Path -Path $ReplyDir -ChildPath $TargetRef.jsonFile) | ConvertFrom-Json
+        foreach ($Source in (Get-MemberValue $TargetJson 'sources' -Or @())) {
+            $CompileGroupIndex = Get-MemberValue $Source 'compileGroupIndex'
+            if ($null -eq $CompileGroupIndex) {
+                continue
+            }
+
+            $RawSourcePath = if ([System.IO.Path]::IsPathRooted($Source.path)) {
+                $Source.path
+            } else {
+                Join-Path -Path $SourceDir -ChildPath $Source.path
+            }
+            $FullSourcePath = [System.IO.Path]::GetFullPath($RawSourcePath)
+
+            if ($FullSourcePath -ieq $SourceFilePath) {
+                $CompileGroup = $TargetJson.compileGroups[$CompileGroupIndex]
+                $RawBuildDir = Join-Path -Path $CodeModel.paths.build -ChildPath $TargetJson.paths.build
+                return [PSCustomObject]@{
+                    Language  = $CompileGroup.language
+                    Fragments = Get-MemberValue $CompileGroup 'compileCommandFragments' -Or @()
+                    Includes  = Get-MemberValue $CompileGroup 'includes' -Or @()
+                    Defines   = Get-MemberValue $CompileGroup 'defines' -Or @()
+                    BuildDir  = [System.IO.Path]::GetFullPath($RawBuildDir)
+                }
+            }
+        }
+    }
+    return $null
+}
+
+<#
+    .Synopsis
+    Parses MSVC /showIncludes output lines into a flat list of include nodes with Depth and Path properties.
+
+    MSVC format: "Note: including file: <N spaces><path>"
+    where N spaces = include depth (1 = directly included).
+#>
+function ParseMSVCIncludes {
+    param(
+        [string[]] $Output
+    )
+    foreach ($Line in $Output) {
+        if ($Line -match '^Note: including file:( +)(.+)$') {
+            [PSCustomObject]@{
+                Depth = $Matches[1].Length
+                Path  = $Matches[2].TrimEnd()
+            }
+        }
+    }
+}
+
+<#
+    .Synopsis
+    Parses Clang -H output lines into a flat list of include nodes with Depth and Path properties.
+
+    Clang format: "<N dots> <path>" where N dots = include depth (1 = directly included).
+#>
+function ParseClangIncludes {
+    param(
+        [string[]] $Output
+    )
+    foreach ($Line in $Output) {
+        if ($Line -match '^(\.+) (.+)$') {
+            [PSCustomObject]@{
+                Depth = $Matches[1].Length
+                Path  = $Matches[2].TrimEnd()
+            }
+        }
+    }
+}

--- a/PSCMake/PSCMake.psd1
+++ b/PSCMake/PSCMake.psd1
@@ -69,7 +69,7 @@ PowerShellVersion = '7.0'
 # NestedModules = @()
 
 # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
-FunctionsToExport = 'Build-CMakeBuild', 'Configure-CMakeBuild', 'Write-CMakeBuild', 'Invoke-CMakeOutput'
+FunctionsToExport = 'Build-CMakeBuild', 'Configure-CMakeBuild', 'Get-CMakeIncludes', 'Write-CMakeBuild', 'Invoke-CMakeOutput'
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
 CmdletsToExport = @()

--- a/PSCMake/PSCMake.psm1
+++ b/PSCMake/PSCMake.psm1
@@ -28,6 +28,7 @@ $ErrorActionPreference = 'Stop'
 
 . $PSScriptRoot/Common/CMake.ps1
 . $PSScriptRoot/Common/Common.ps1
+. $PSScriptRoot/Common/Includes.ps1
 . $PSScriptRoot/Common/Ninja.ps1
 
 <#
@@ -591,6 +592,134 @@ function Invoke-CMakeOutput {
     InvokeExecutable $TargetPath $Arguments
 }
 
+<#
+    .Synopsis
+    Recompiles a single source file and returns the include tree captured by the compiler.
+
+    .Description
+    `Get-CMakeIncludes` recompiles the given source file with include reporting enabled (/showIncludes for MSVC,
+    -H for Clang) and returns the include tree as a flat list of objects with Depth and Path properties. The
+    compile flags, include paths, and defines are read from the CMake File API code model for the given preset
+    and configuration, so no manual compiler invocation is needed.
+
+    Supported compilers: MSVC, Clang, AppleClang.
+
+    .Parameter Preset
+    The CMake build preset to use. If none is specified, the first available build preset is used.
+
+    .Parameter Configuration
+    The CMake configuration (e.g. 'Debug', 'Release'). If none is specified, the first available configuration
+    in the code model is used.
+
+    .Parameter SourceFile
+    Path to the C++ source file to analyze. May be absolute or relative to the current directory.
+
+    .Example
+    # Show all headers included when compiling MyFile.cpp for the windows-x64 preset.
+    Get-CMakeIncludes -Preset windows-x64 -Configuration Debug -SourceFile src/MyFile.cpp
+
+    .Example
+    # Find the deepest include chains for a file.
+    Get-CMakeIncludes windows-x64 Debug src/MyFile.cpp | Sort-Object Depth -Descending | Select-Object -First 10
+#>
+function Get-CMakeIncludes {
+    [CmdletBinding()]
+    param(
+        [Parameter(Position = 0)]
+        [string] $Preset,
+
+        [Parameter(Position = 1)]
+        [string] $Configuration,
+
+        [Parameter(Mandatory, Position = 2)]
+        [string] $SourceFile
+    )
+    $CMakePresetsJson = GetCMakePresets
+    $BuildPreset = GetMatchingBuildPresets $CMakePresetsJson $Preset | Select-Object -First 1
+    $ConfigurePreset = GetConfigurePresetFor $CMakePresetsJson $BuildPreset
+    $BinaryDirectory = GetBinaryDirectory $CMakePresetsJson $ConfigurePreset
+
+    $CodeModel = Get-CMakeBuildCodeModel $BinaryDirectory
+    if (-not $CodeModel) {
+        Write-Error "No code model found in '$BinaryDirectory'. Run Configure-CMakeBuild first."
+    }
+
+    $Toolchains = Get-CMakeBuildToolchains $BinaryDirectory
+    if (-not $Toolchains) {
+        Write-Error "No toolchain information found in '$BinaryDirectory'. Run Configure-CMakeBuild first."
+    }
+
+    $SourceFilePath = (Resolve-Path -LiteralPath $SourceFile).Path
+    $CompileInfo = GetCompileInfoForSource $CodeModel $BinaryDirectory $Configuration $SourceFilePath
+    if (-not $CompileInfo) {
+        Write-Error "Source file '$SourceFile' was not found in any target's source list."
+    }
+
+    $Toolchain = $Toolchains.toolchains | Where-Object { $_.language -eq $CompileInfo.Language } | Select-Object -First 1
+    if (-not $Toolchain) {
+        Write-Error "No toolchain found for language '$($CompileInfo.Language)'."
+    }
+
+    # Get the CompilerId
+    #
+    # If a 'CMAKE_<LANG>_COMPILER_FRONTEND_VARIANT' is in the cache, then use that. Otherwise, use the 'id' field from
+    # the toolchain JSON.
+    $Language = $CompileInfo.Language
+    $CompilerFrontendId = GetCacheValue $BinaryDirectory "CMAKE_$($Language)_COMPILER_FRONTEND_VARIANT"
+    $CompilerId = if ($CompilerFrontendId) {
+        $CompilerFrontendId
+    } else {
+        Get-MemberValue $Toolchain.compiler 'id'
+    }
+    if ($CompilerId -notin @('MSVC', 'Clang', 'AppleClang')) {
+        Write-Error "Compiler '$CompilerId' does not support include reporting via PSCMake. Supported compilers: MSVC, Clang."
+    }
+
+    Write-Verbose "Get-CMakeIncludes: Compiler ID: $CompilerId"
+
+    $CompilerPath = $Toolchain.compiler.path
+    $CompilerArgs = @()
+
+    $CompilerArgs += $CompileInfo.Fragments |
+        ForEach-Object { $_.fragment -split '\s+' } |
+        Where-Object { $_ }
+
+    $CompilerArgs += if ($CompilerId -eq 'MSVC') {
+        $CompileInfo.Includes | ForEach-Object { "/I"; $_.path }
+    } else {
+        $CompileInfo.Includes | ForEach-Object { "-I"; $_.path }
+    }
+
+    $CompilerArgs += if ($CompilerId -eq 'MSVC') {
+        $CompileInfo.Defines | ForEach-Object { "/D$($_.define)" }
+    } else {
+        $CompileInfo.Defines | ForEach-Object { "-D$($_.define)" }
+    }
+
+    if ($CompilerId -eq 'MSVC') {
+        $CompilerArgs += @('/showIncludes', '/nologo', '/c', $SourceFilePath, '/Zs')
+    } else {
+        $CompilerArgs += @('-H', '-c', $SourceFilePath, '-fsyntax-only')
+    }
+
+    Write-Verbose "Get-CMakeIncludes: Compiler : $CompilerPath"
+    Write-Verbose "Get-CMakeIncludes: Arguments: $($CompilerArgs -join ' ')"
+
+    $Output = Using-Location $CompileInfo.BuildDir {
+        InvokeCompilerForIncludes $CompilerPath $CompilerArgs
+    }
+
+    if ($LASTEXITCODE -ne 0) {
+        Write-Warning "Get-CMakeIncludes: Compiler exited with code $LASTEXITCODE. Include information may be incomplete."
+    }
+
+    if ($CompilerId -eq 'MSVC') {
+        ParseMSVCIncludes $Output
+    } else {
+        ParseClangIncludes $Output
+    }
+}
+
 Register-ArgumentCompleter -CommandName Invoke-CMakeOutput -ParameterName Preset -ScriptBlock $function:BuildPresetsCompleter
 Register-ArgumentCompleter -CommandName Invoke-CMakeOutput -ParameterName Configuration -ScriptBlock $function:BuildConfigurationsCompleter
 Register-ArgumentCompleter -CommandName Invoke-CMakeOutput -ParameterName Target -ScriptBlock $function:ExecutableTargetsCompleter
@@ -603,3 +732,6 @@ Register-ArgumentCompleter -CommandName Configure-CMakeBuild -ParameterName Pres
 
 Register-ArgumentCompleter -CommandName Write-CMakeBuild -ParameterName Preset -ScriptBlock $function:BuildPresetsCompleter
 Register-ArgumentCompleter -CommandName Write-CMakeBuild -ParameterName Configuration -ScriptBlock $function:BuildConfigurationsCompleter
+
+Register-ArgumentCompleter -CommandName Get-CMakeIncludes -ParameterName Preset -ScriptBlock $function:BuildPresetsCompleter
+Register-ArgumentCompleter -CommandName Get-CMakeIncludes -ParameterName Configuration -ScriptBlock $function:BuildConfigurationsCompleter

--- a/Tests/Get-CMakeIncludes.Tests.ps1
+++ b/Tests/Get-CMakeIncludes.Tests.ps1
@@ -1,0 +1,183 @@
+#Requires -PSEdition Core
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+BeforeAll {
+    . $PSScriptRoot/TestUtilities.ps1
+    . $PSScriptRoot/ReferenceBuild.ps1
+    . $PSScriptRoot/../PSCMake/Common/Includes.ps1
+
+    $script:Props = GetReferenceBuildProperties
+}
+
+Describe 'ParseMSVCIncludes' {
+    It 'Parses a single depth-1 include' {
+        $Result = ParseMSVCIncludes @('Note: including file: C:\Windows\include\windows.h')
+        $Result | Should -HaveCount 1
+        $Result[0].Depth | Should -Be 1
+        $Result[0].Path | Should -Be 'C:\Windows\include\windows.h'
+    }
+
+    It 'Parses nested includes at increasing depths' {
+        $Output = @(
+            'Note: including file: C:\include\a.h'
+            'Note: including file:  C:\include\b.h'
+            'Note: including file:   C:\include\c.h'
+            'Note: including file:  C:\include\d.h'
+        )
+        $Result = ParseMSVCIncludes $Output
+        $Result | Should -HaveCount 4
+        $Result[0].Depth | Should -Be 1
+        $Result[1].Depth | Should -Be 2
+        $Result[2].Depth | Should -Be 3
+        $Result[3].Depth | Should -Be 2
+    }
+
+    It 'Ignores non-include lines' {
+        $Output = @(
+            'Reference.cpp'
+            'Note: including file: C:\include\a.h'
+            'cl: warning D9025: ...'
+        )
+        $Result = ParseMSVCIncludes $Output
+        $Result | Should -HaveCount 1
+        $Result[0].Path | Should -Be 'C:\include\a.h'
+    }
+
+    It 'Returns nothing for empty output' {
+        $Result = ParseMSVCIncludes @()
+        $Result | Should -BeNullOrEmpty
+    }
+
+    It 'Returns nothing when no include lines are present' {
+        $Result = ParseMSVCIncludes @('Reference.cpp', 'Build succeeded.')
+        $Result | Should -BeNullOrEmpty
+    }
+}
+
+Describe 'ParseClangIncludes' {
+    It 'Parses a single depth-1 include' {
+        $Result = ParseClangIncludes @('. /usr/include/stdio.h')
+        $Result | Should -HaveCount 1
+        $Result[0].Depth | Should -Be 1
+        $Result[0].Path | Should -Be '/usr/include/stdio.h'
+    }
+
+    It 'Parses nested includes at increasing depths' {
+        $Output = @(
+            '. /usr/include/a.h'
+            '.. /usr/include/b.h'
+            '... /usr/include/c.h'
+            '.. /usr/include/d.h'
+        )
+        $Result = ParseClangIncludes $Output
+        $Result | Should -HaveCount 4
+        $Result[0].Depth | Should -Be 1
+        $Result[1].Depth | Should -Be 2
+        $Result[2].Depth | Should -Be 3
+        $Result[3].Depth | Should -Be 2
+    }
+
+    It 'Ignores non-include lines' {
+        $Output = @(
+            'In file included from /path/to/file.cpp:1:'
+            '. /usr/include/a.h'
+            'clang: warning: unused variable'
+        )
+        $Result = ParseClangIncludes $Output
+        $Result | Should -HaveCount 1
+        $Result[0].Path | Should -Be '/usr/include/a.h'
+    }
+
+    It 'Returns nothing for empty output' {
+        $Result = ParseClangIncludes @()
+        $Result | Should -BeNullOrEmpty
+    }
+}
+
+Describe 'Get-CMakeBuildToolchains' {
+    It 'Returns toolchain data from the reference build' {
+        $Toolchains = Get-CMakeBuildToolchains $script:Props.BinaryDirectory
+        $Toolchains | Should -Not -BeNullOrEmpty
+        $Toolchains.toolchains | Should -Not -BeNullOrEmpty
+    }
+
+    It 'Exposes a CXX toolchain with MSVC compiler' {
+        $Toolchains = Get-CMakeBuildToolchains $script:Props.BinaryDirectory
+        $CxxToolchain = $Toolchains.toolchains | Where-Object { $_.language -eq 'CXX' }
+        $CxxToolchain | Should -Not -BeNullOrEmpty
+        $CxxToolchain.compiler.id | Should -Be 'MSVC'
+        $CxxToolchain.compiler.path | Should -Not -BeNullOrEmpty
+    }
+}
+
+Describe 'GetCompileInfoForSource' {
+    It 'Returns compile info for a source file present in a target' {
+        $SourcePath = Join-Path -Path $script:Props.SourceDirectory -ChildPath 'Reference.cpp'
+        $Result = GetCompileInfoForSource $script:Props.CodeModelFile $script:Props.BinaryDirectory $null $SourcePath
+        $Result | Should -Not -BeNullOrEmpty
+        $Result.Language | Should -Be 'CXX'
+        $Result.Fragments | Should -Not -BeNullOrEmpty
+        $Result.BuildDir | Should -Not -BeNullOrEmpty
+    }
+
+    It 'Returns null for a source file not in any target' {
+        $SourcePath = Join-Path -Path $script:Props.SourceDirectory -ChildPath 'DoesNotExist.cpp'
+        $Result = GetCompileInfoForSource $script:Props.CodeModelFile $script:Props.BinaryDirectory $null $SourcePath
+        $Result | Should -BeNullOrEmpty
+    }
+
+    It 'Resolves the build directory to an absolute path' {
+        $SourcePath = Join-Path -Path $script:Props.SourceDirectory -ChildPath 'Reference.cpp'
+        $Result = GetCompileInfoForSource $script:Props.CodeModelFile $script:Props.BinaryDirectory $null $SourcePath
+        [System.IO.Path]::IsPathRooted($Result.BuildDir) | Should -BeTrue
+    }
+}
+
+Describe 'Get-CMakeIncludes' {
+    BeforeAll {
+        Import-Module -Force $PSScriptRoot/../PSCMake/PSCMake.psd1 -DisableNameChecking
+
+        $script:CompilerCalls = @()
+        Mock -ModuleName PSCMake InvokeCompilerForIncludes {
+            param([string] $Path, [string[]] $Arguments)
+            $script:CompilerCalls += , @{ Path = $Path; Arguments = $Arguments }
+            @(
+                'Reference.cpp'
+                'Note: including file: C:\Windows\Kits\10\include\10.0.26100.0\ucrt\stdio.h'
+                'Note: including file:  C:\Windows\Kits\10\include\10.0.26100.0\ucrt\corecrt.h'
+            )
+        }
+    }
+
+    BeforeEach {
+        $script:CompilerCalls = @()
+    }
+
+    It 'Returns include nodes for a source file' {
+        Using-Location "$PSScriptRoot/ReferenceBuild" {
+            $Result = Get-CMakeIncludes -Preset windows-x64 -Configuration Debug -SourceFile Reference.cpp
+            $Result | Should -HaveCount 2
+            $Result[0].Depth | Should -Be 1
+            $Result[1].Depth | Should -Be 2
+        }
+    }
+
+    It 'Passes /showIncludes and /nologo to the MSVC compiler' {
+        Using-Location "$PSScriptRoot/ReferenceBuild" {
+            $null = Get-CMakeIncludes -Preset windows-x64 -Configuration Debug -SourceFile Reference.cpp
+        }
+        $script:CompilerCalls | Should -HaveCount 1
+        $script:CompilerCalls[0].Arguments | Should -Contain '/showIncludes'
+        $script:CompilerCalls[0].Arguments | Should -Contain '/nologo'
+        $script:CompilerCalls[0].Arguments | Should -Contain '/c'
+    }
+
+    It 'Invokes the compiler path from the toolchain' {
+        Using-Location "$PSScriptRoot/ReferenceBuild" {
+            $null = Get-CMakeIncludes -Preset windows-x64 -Configuration Debug -SourceFile Reference.cpp
+        }
+        $script:CompilerCalls[0].Path | Should -Match 'cl\.exe$'
+    }
+}


### PR DESCRIPTION
This PR starts building some higher-level functionality into PSCMake - leveraging the description of the build provided by CMake file-api it provides 'Get-CMakeIncludes', which returns the ordered tree of includes of a given .cpp file. There's a good amount of plumbing and precedent here - searching CMake metadata for source files, identifying their target, building a compilation command-line, augmenting and then running it. There's Pester tests, and I've validated with msvc, clang, clang-cl.

There's definitely opportunities for improvement (rendering a tree would be nice; tab-completion on the 'SourceFile' parameter), but I'd love to get this in for feedback and to try it out broadly. And there's definitely opportunities for other use cases (getting the preprocessed output of a source file; analysis for module/pch creation; analysis of CMake 'correctness').