### PR TITLE
Add 'Get-CMakePreprocess'

### DIFF
--- a/PSCMake/Common/Includes.ps1
+++ b/PSCMake/Common/Includes.ps1
@@ -28,21 +28,6 @@ $ErrorActionPreference = 'Stop'
 
 <#
     .Synopsis
-    Invokes the compiler and returns combined stdout+stderr as an array of strings.
-
-    .Description
-    A function wrapping the compiler invocation, allowing it to be mocked for testing.
-#>
-function InvokeCompilerForIncludes {
-    param(
-        [string] $Path,
-        [string[]] $Arguments
-    )
-    & $Path @Arguments 2>&1 | ForEach-Object { "$_" }
-}
-
-<#
-    .Synopsis
     Reads the toolchains-v1 File API reply for the given binary directory.
 #>
 function Get-CMakeBuildToolchains {
@@ -53,6 +38,67 @@ function Get-CMakeBuildToolchains {
         Select-Object -First 1 |
         Get-Content |
         ConvertFrom-Json
+}
+
+<#
+    .Synopsis
+    Resolves the compiler path, ID, and base argument list for a given source file.
+
+    .Description
+    Looks up the compile group for $SourceFilePath in the code model, determines the compiler ID (preferring
+    CMAKE_<LANG>_COMPILER_FRONTEND_VARIANT when present), and builds the fragment/include/define arguments.
+    Returns a PSCustomObject with CompilerId, CompilerPath, CompilerArgs, and BuildDir, or $null if the source
+    file was not found in any target.
+#>
+function GetCompilerInvocationForSource {
+    param(
+        $CodeModel,
+        $Toolchains,
+        [string] $BinaryDirectory,
+        [string] $Configuration,
+        [string] $SourceFilePath
+    )
+    $CompileInfo = GetCompileInfoForSource $CodeModel $BinaryDirectory $Configuration $SourceFilePath
+    if (-not $CompileInfo) {
+        return $null
+    }
+
+    $Toolchain = $Toolchains.toolchains | Where-Object { $_.language -eq $CompileInfo.Language } | Select-Object -First 1
+    if (-not $Toolchain) {
+        Write-Error "No toolchain found for language '$($CompileInfo.Language)'."
+    }
+
+    # Prefer CMAKE_<LANG>_COMPILER_FRONTEND_VARIANT when set; it reflects the actual flag syntax
+    # (e.g. clang-cl reports 'MSVC' here even though the compiler id is 'Clang').
+    $Language = $CompileInfo.Language
+    $CompilerFrontendId = GetCacheValue $BinaryDirectory "CMAKE_$($Language)_COMPILER_FRONTEND_VARIANT"
+    $CompilerId = if ($CompilerFrontendId) { $CompilerFrontendId } else { Get-MemberValue $Toolchain.compiler 'id' }
+
+    if ($CompilerId -notin @('MSVC', 'Clang', 'AppleClang')) {
+        Write-Error "Compiler '$CompilerId' is not supported by PSCMake. Supported compilers: MSVC, Clang, AppleClang."
+    }
+
+    $CompilerArgs = @()
+    $CompilerArgs += $CompileInfo.Fragments |
+        ForEach-Object { $_.fragment -split '\s+' } |
+        Where-Object { $_ }
+    $CompilerArgs += if ($CompilerId -eq 'MSVC') {
+        $CompileInfo.Includes | ForEach-Object { "/I"; $_.path }
+    } else {
+        $CompileInfo.Includes | ForEach-Object { "-I"; $_.path }
+    }
+    $CompilerArgs += if ($CompilerId -eq 'MSVC') {
+        $CompileInfo.Defines | ForEach-Object { "/D$($_.define)" }
+    } else {
+        $CompileInfo.Defines | ForEach-Object { "-D$($_.define)" }
+    }
+
+    [PSCustomObject]@{
+        CompilerId   = $CompilerId
+        CompilerPath = $Toolchain.compiler.path
+        CompilerArgs = $CompilerArgs
+        BuildDir     = $CompileInfo.BuildDir
+    }
 }
 
 <#

--- a/PSCMake/PSCMake.psd1
+++ b/PSCMake/PSCMake.psd1
@@ -69,7 +69,7 @@ PowerShellVersion = '7.0'
 # NestedModules = @()
 
 # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
-FunctionsToExport = 'Build-CMakeBuild', 'Configure-CMakeBuild', 'Get-CMakeIncludes', 'Write-CMakeBuild', 'Invoke-CMakeOutput'
+FunctionsToExport = 'Build-CMakeBuild', 'Configure-CMakeBuild', 'Get-CMakeIncludes', 'Get-CMakePreprocess', 'Write-CMakeBuild', 'Invoke-CMakeOutput'
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
 CmdletsToExport = @()

--- a/PSCMake/PSCMake.psm1
+++ b/PSCMake/PSCMake.psm1
@@ -671,75 +671,124 @@ function Get-CMakeIncludes {
     }
 
     $SourceFilePath = (Resolve-Path -LiteralPath $SourceFile).Path
-    $CompileInfo = GetCompileInfoForSource $CodeModel $BinaryDirectory $Configuration $SourceFilePath
-    if (-not $CompileInfo) {
+    $Invocation = GetCompilerInvocationForSource $CodeModel $Toolchains $BinaryDirectory $Configuration $SourceFilePath
+    if (-not $Invocation) {
         Write-Error "Source file '$SourceFile' was not found in any target's source list."
     }
 
-    $Toolchain = $Toolchains.toolchains | Where-Object { $_.language -eq $CompileInfo.Language } | Select-Object -First 1
-    if (-not $Toolchain) {
-        Write-Error "No toolchain found for language '$($CompileInfo.Language)'."
-    }
-
-    # Get the CompilerId
-    #
-    # If a 'CMAKE_<LANG>_COMPILER_FRONTEND_VARIANT' is in the cache, then use that. Otherwise, use the 'id' field from
-    # the toolchain JSON.
-    $Language = $CompileInfo.Language
-    $CompilerFrontendId = GetCacheValue $BinaryDirectory "CMAKE_$($Language)_COMPILER_FRONTEND_VARIANT"
-    $CompilerId = if ($CompilerFrontendId) {
-        $CompilerFrontendId
-    } else {
-        Get-MemberValue $Toolchain.compiler 'id'
-    }
-    if ($CompilerId -notin @('MSVC', 'Clang', 'AppleClang')) {
-        Write-Error "Compiler '$CompilerId' does not support include reporting via PSCMake. Supported compilers: MSVC, Clang."
-    }
-
-    Write-Verbose "Get-CMakeIncludes: Compiler ID: $CompilerId"
-
-    $CompilerPath = $Toolchain.compiler.path
-    $CompilerArgs = @()
-
-    $CompilerArgs += $CompileInfo.Fragments |
-        ForEach-Object { $_.fragment -split '\s+' } |
-        Where-Object { $_ }
-
-    $CompilerArgs += if ($CompilerId -eq 'MSVC') {
-        $CompileInfo.Includes | ForEach-Object { "/I"; $_.path }
-    } else {
-        $CompileInfo.Includes | ForEach-Object { "-I"; $_.path }
-    }
-
-    $CompilerArgs += if ($CompilerId -eq 'MSVC') {
-        $CompileInfo.Defines | ForEach-Object { "/D$($_.define)" }
-    } else {
-        $CompileInfo.Defines | ForEach-Object { "-D$($_.define)" }
-    }
-
-    if ($CompilerId -eq 'MSVC') {
+    $CompilerArgs = $Invocation.CompilerArgs
+    if ($Invocation.CompilerId -eq 'MSVC') {
         $CompilerArgs += @('/showIncludes', '/nologo', '/c', $SourceFilePath, '/Zs')
     } else {
         $CompilerArgs += @('-H', '-c', $SourceFilePath, '-fsyntax-only')
     }
 
-    Write-Verbose "Get-CMakeIncludes: Compiler : $CompilerPath"
+    Write-Verbose "Get-CMakeIncludes: Compiler ID: $($Invocation.CompilerId)"
+    Write-Verbose "Get-CMakeIncludes: Compiler : $($Invocation.CompilerPath)"
     Write-Verbose "Get-CMakeIncludes: Arguments: $($CompilerArgs -join ' ')"
 
-    $Output = Using-Location $CompileInfo.BuildDir {
-        InvokeCompilerForIncludes $CompilerPath $CompilerArgs
+    $Output = Using-Location $Invocation.BuildDir {
+        InvokeExecutable $Invocation.CompilerPath $CompilerArgs
     }
 
-    if ($LASTEXITCODE -ne 0) {
+    if ((Test-Path variable:LASTEXITCODE) -and ($LASTEXITCODE -ne 0)) {
         Write-Warning "Get-CMakeIncludes: Compiler exited with code $LASTEXITCODE. Include information may be incomplete."
     }
 
-    if ($CompilerId -eq 'MSVC') {
+    if ($Invocation.CompilerId -eq 'MSVC') {
         ParseMSVCIncludes $Output
     } else {
         ParseClangIncludes $Output
     }
 }
+
+<#
+    .Synopsis
+    Recompiles a single source file and returns the preprocessed output.
+
+    .Description
+    `Get-CMakePreprocess` recompiles the given source file in preprocessing mode (/E for MSVC, -E for Clang)
+    and returns the preprocessed source as a flat list of strings. The compile flags, include paths, and
+    defines are read from the CMake File API code model for the given preset and configuration, so no manual
+    compiler invocation is needed.
+
+    Supported compilers: MSVC, Clang, AppleClang.
+
+    .Parameter Preset
+    The CMake build preset to use. If none is specified, the first available build preset is used.
+
+    .Parameter Configuration
+    The CMake configuration (e.g. 'Debug', 'Release'). If none is specified, the first available configuration
+    in the code model is used.
+
+    .Parameter SourceFile
+    Path to the C++ source file to preprocess. May be absolute or relative to the current directory.
+
+    .Example
+    # Preprocess MyFile.cpp and write the output to a file.
+    Get-CMakePreprocess -Preset windows-x64 -Configuration Debug -SourceFile src/MyFile.cpp | Set-Content MyFile.i
+
+    .Example
+    # Count the lines in the preprocessed output.
+    (Get-CMakePreprocess windows-x64 Debug src/MyFile.cpp).Count
+#>
+function Get-CMakePreprocess {
+    [CmdletBinding()]
+    param(
+        [Parameter(Position = 0)]
+        [string] $Preset,
+
+        [Parameter(Position = 1)]
+        [string] $Configuration,
+
+        [Parameter(Mandatory, Position = 2)]
+        [string] $SourceFile
+    )
+    $CMakePresetsJson = GetCMakePresets
+    $BuildPreset = GetMatchingBuildPresets $CMakePresetsJson $Preset | Select-Object -First 1
+    $ConfigurePreset = GetConfigurePresetFor $CMakePresetsJson $BuildPreset
+    $BinaryDirectory = GetBinaryDirectory $CMakePresetsJson $ConfigurePreset
+
+    $CodeModel = Get-CMakeBuildCodeModel $BinaryDirectory
+    if (-not $CodeModel) {
+        Write-Error "No code model found in '$BinaryDirectory'. Run Configure-CMakeBuild first."
+    }
+
+    $Toolchains = Get-CMakeBuildToolchains $BinaryDirectory
+    if (-not $Toolchains) {
+        Write-Error "No toolchain information found in '$BinaryDirectory'. Run Configure-CMakeBuild first."
+    }
+
+    $SourceFilePath = (Resolve-Path -LiteralPath $SourceFile).Path
+    $Invocation = GetCompilerInvocationForSource $CodeModel $Toolchains $BinaryDirectory $Configuration $SourceFilePath
+    if (-not $Invocation) {
+        Write-Error "Source file '$SourceFile' was not found in any target's source list."
+    }
+
+    $CompilerArgs = $Invocation.CompilerArgs
+    if ($Invocation.CompilerId -eq 'MSVC') {
+        $CompilerArgs += @('/nologo', '/E', $SourceFilePath)
+    } else {
+        $CompilerArgs += @('-E', $SourceFilePath)
+    }
+
+    Write-Verbose "Get-CMakePreprocess: Compiler ID: $($Invocation.CompilerId)"
+    Write-Verbose "Get-CMakePreprocess: Compiler : $($Invocation.CompilerPath)"
+    Write-Verbose "Get-CMakePreprocess: Arguments: $($CompilerArgs -join ' ')"
+
+    $Output = Using-Location $Invocation.BuildDir {
+        InvokeExecutable $Invocation.CompilerPath $CompilerArgs
+    }
+
+    if ((Test-Path variable:LASTEXITCODE) -and ($LASTEXITCODE -ne 0)) {
+        Write-Warning "Get-CMakePreprocess: Compiler exited with code $LASTEXITCODE. Output may be incomplete."
+    }
+
+    $Output
+}
+
+Register-ArgumentCompleter -CommandName Get-CMakePreprocess -ParameterName Preset -ScriptBlock $function:BuildPresetsCompleter
+Register-ArgumentCompleter -CommandName Get-CMakePreprocess -ParameterName Configuration -ScriptBlock $function:BuildConfigurationsCompleter
 
 Register-ArgumentCompleter -CommandName Invoke-CMakeOutput -ParameterName Preset -ScriptBlock $function:BuildPresetsCompleter
 Register-ArgumentCompleter -CommandName Invoke-CMakeOutput -ParameterName Configuration -ScriptBlock $function:BuildConfigurationsCompleter

--- a/Tests/Get-CMakeIncludes.Tests.ps1
+++ b/Tests/Get-CMakeIncludes.Tests.ps1
@@ -140,7 +140,7 @@ Describe 'Get-CMakeIncludes' {
         Import-Module -Force $PSScriptRoot/../PSCMake/PSCMake.psd1 -DisableNameChecking
 
         $script:CompilerCalls = @()
-        Mock -ModuleName PSCMake InvokeCompilerForIncludes {
+        Mock -ModuleName PSCMake InvokeExecutable {
             param([string] $Path, [string[]] $Arguments)
             $script:CompilerCalls += , @{ Path = $Path; Arguments = $Arguments }
             @(

--- a/Tests/Get-CMakePreprocess.Tests.ps1
+++ b/Tests/Get-CMakePreprocess.Tests.ps1
@@ -1,0 +1,65 @@
+#Requires -PSEdition Core
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+BeforeAll {
+    . $PSScriptRoot/TestUtilities.ps1
+    . $PSScriptRoot/ReferenceBuild.ps1
+    . $PSScriptRoot/../PSCMake/Common/Includes.ps1
+
+    $script:Props = GetReferenceBuildProperties
+}
+
+Describe 'Get-CMakePreprocess' {
+    BeforeAll {
+        Import-Module -Force $PSScriptRoot/../PSCMake/PSCMake.psd1 -DisableNameChecking
+
+        $script:CompilerCalls = @()
+        Mock -ModuleName PSCMake InvokeExecutable {
+            param([string] $Path, [string[]] $Arguments)
+            $script:CompilerCalls += , @{ Path = $Path; Arguments = $Arguments }
+            @(
+                '# 1 "Reference.cpp"'
+                '#include <stdio.h>'
+                'int main() { return 0; }'
+            )
+        }
+    }
+
+    BeforeEach {
+        $script:CompilerCalls = @()
+    }
+
+    It 'Returns preprocessed output lines for a source file' {
+        Using-Location "$PSScriptRoot/ReferenceBuild" {
+            $Result = Get-CMakePreprocess -Preset windows-x64 -Configuration Debug -SourceFile Reference.cpp
+            $Result | Should -HaveCount 3
+        }
+    }
+
+    It 'Passes /E and /nologo to the MSVC compiler' {
+        Using-Location "$PSScriptRoot/ReferenceBuild" {
+            $null = Get-CMakePreprocess -Preset windows-x64 -Configuration Debug -SourceFile Reference.cpp
+        }
+        $script:CompilerCalls | Should -HaveCount 1
+        $script:CompilerCalls[0].Arguments | Should -Contain '/E'
+        $script:CompilerCalls[0].Arguments | Should -Contain '/nologo'
+    }
+
+    It 'Does not pass /c, /Zs, or /showIncludes to the MSVC compiler' {
+        Using-Location "$PSScriptRoot/ReferenceBuild" {
+            $null = Get-CMakePreprocess -Preset windows-x64 -Configuration Debug -SourceFile Reference.cpp
+        }
+        $script:CompilerCalls[0].Arguments | Should -Not -Contain '/c'
+        $script:CompilerCalls[0].Arguments | Should -Not -Contain '/Zs'
+        $script:CompilerCalls[0].Arguments | Should -Not -Contain '/showIncludes'
+    }
+
+    It 'Invokes the compiler path from the toolchain' {
+        Using-Location "$PSScriptRoot/ReferenceBuild" {
+            $null = Get-CMakePreprocess -Preset windows-x64 -Configuration Debug -SourceFile Reference.cpp
+        }
+        $script:CompilerCalls[0].Path | Should -Match 'cl\.exe$'
+    }
+}


### PR DESCRIPTION
Following the precedent of `Get-CMakeIncludes`, this PR adds `Get-CMakePreprocess` - returning the preprocessed output of a source file. A good amount of the infrastructure from `Get-CMakeIncludes` can be reused, so I introduced `GetCompilerInvocationForSource` to get the full details of how the given source file is compiled (CompilerId, CompilerPath, CompilerArgs, BuildPath) and then `Get-CMakeIncludes`  or `Get-CMakePreprocess` can add the few options they need.