### PR TITLE
Use a custom formatter for Get-CMakeIncludes output

### DIFF
--- a/PSCMake/Common/Includes.ps1
+++ b/PSCMake/Common/Includes.ps1
@@ -170,6 +170,7 @@ function ParseMSVCIncludes {
     foreach ($Line in $Output) {
         if ($Line -match '^Note: including file:( +)(.+)$') {
             [PSCustomObject]@{
+                PSTypeName = 'PSCMake.IncludeNode'
                 Depth = $Matches[1].Length
                 Path  = $Matches[2].TrimEnd()
             }
@@ -190,6 +191,7 @@ function ParseClangIncludes {
     foreach ($Line in $Output) {
         if ($Line -match '^(\.+) (.+)$') {
             [PSCustomObject]@{
+                PSTypeName = 'PSCMake.IncludeNode'
                 Depth = $Matches[1].Length
                 Path  = $Matches[2].TrimEnd()
             }

--- a/PSCMake/PSCMake.Format.ps1xml
+++ b/PSCMake/PSCMake.Format.ps1xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  MIT License
+
+  Copyright (c) 2025 Mark Schofield
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+-->
+<Configuration>
+  <ViewDefinitions>
+
+    <!--
+      PSCMake.IncludeNode — emitted by Get-CMakeIncludes.
+      Renders a flat list of include nodes as a Unicode tree, using the Depth
+      property to compute the indentation prefix for each entry.
+    -->
+    <View>
+      <Name>PSCMake.IncludeNode</Name>
+      <ViewSelectedBy>
+        <TypeName>PSCMake.IncludeNode</TypeName>
+      </ViewSelectedBy>
+      <CustomControl>
+        <CustomEntries>
+          <CustomEntry>
+            <CustomItem>
+              <ExpressionBinding>
+                <ScriptBlock>
+                  ("│   " * ([int]$_.Depth - 1)) + "├── " + $_.Path
+                </ScriptBlock>
+              </ExpressionBinding>
+            </CustomItem>
+          </CustomEntry>
+        </CustomEntries>
+      </CustomControl>
+    </View>
+
+  </ViewDefinitions>
+</Configuration>

--- a/PSCMake/PSCMake.psd1
+++ b/PSCMake/PSCMake.psd1
@@ -63,7 +63,7 @@ PowerShellVersion = '7.0'
 # TypesToProcess = @()
 
 # Format files (.ps1xml) to be loaded when importing this module
-# FormatsToProcess = @()
+FormatsToProcess = @('PSCMake.Format.ps1xml')
 
 # Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
 # NestedModules = @()

--- a/Tests/Get-CMakeIncludes.Tests.ps1
+++ b/Tests/Get-CMakeIncludes.Tests.ps1
@@ -164,6 +164,13 @@ Describe 'Get-CMakeIncludes' {
         }
     }
 
+    It 'Returns nodes typed as PSCMake.IncludeNode' {
+        Using-Location "$PSScriptRoot/ReferenceBuild" {
+            $Result = Get-CMakeIncludes -Preset windows-x64 -Configuration Debug -SourceFile Reference.cpp
+            $Result[0].PSObject.TypeNames | Should -Contain 'PSCMake.IncludeNode'
+        }
+    }
+
     It 'Passes /showIncludes and /nologo to the MSVC compiler' {
         Using-Location "$PSScriptRoot/ReferenceBuild" {
             $null = Get-CMakeIncludes -Preset windows-x64 -Configuration Debug -SourceFile Reference.cpp


### PR DESCRIPTION
This PR introduces 'PSCMake/PSCMake.Format.ps1xml' for custom formatting PSCMake types, registering it in the `PSCMake/PSCMake.psd1`, and adds a formatter for the output items from `Get-CMakeIncludes`.