### PR TITLE
Get-CMakeIncludes should parse error output

### DIFF
--- a/PSCMake/PSCMake.psm1
+++ b/PSCMake/PSCMake.psm1
@@ -696,7 +696,7 @@ function Get-CMakeIncludes {
     Write-Verbose "Get-CMakeIncludes: Arguments: $($CompilerArgs -join ' ')"
 
     $Output = Using-Location $Invocation.BuildDir {
-        InvokeExecutable $Invocation.CompilerPath $CompilerArgs
+        InvokeExecutable $Invocation.CompilerPath $CompilerArgs 2>&1
     }
 
     if ((Test-Path variable:LASTEXITCODE) -and ($LASTEXITCODE -ne 0)) {


### PR DESCRIPTION
Fixes #102

Clang compilers write the `-H` include information to stderror, not stdoutput. `Get-CMakeIncludes` should really redirect stderror to stdoutput to process all output.