### PR TITLE
Rename plural noun cmdlets

### DIFF
--- a/PSCMake/Common/Common.ps1
+++ b/PSCMake/Common/Common.ps1
@@ -84,7 +84,7 @@ function IsUpToDate($Target) {
 <#
     .Synopsis
     Temporarily changes the current location to the given path, runs the script block, then restores the
-    original location — even if the script block throws.
+    original location - even if the script block throws.
 #>
 function Using-Location($Location, $Scriptlet) {
     Push-Location -Path $Location

--- a/PSCMake/Common/Includes.ps1
+++ b/PSCMake/Common/Includes.ps1
@@ -30,7 +30,7 @@ $ErrorActionPreference = 'Stop'
     .Synopsis
     Reads the toolchains-v1 File API reply for the given binary directory.
 #>
-function Get-CMakeBuildToolchains {
+function Get-CMakeBuildToolchain {
     param(
         [string] $BinaryDirectory
     )

--- a/PSCMake/PSCMake.Format.ps1xml
+++ b/PSCMake/PSCMake.Format.ps1xml
@@ -26,7 +26,7 @@
   <ViewDefinitions>
 
     <!--
-      PSCMake.IncludeNode — emitted by Get-CMakeIncludes.
+      PSCMake.IncludeNode — emitted by Get-CMakeInclude.
       Renders a flat list of include nodes as a Unicode tree, using the Depth
       property to compute the indentation prefix for each entry.
     -->

--- a/PSCMake/PSCMake.psd1
+++ b/PSCMake/PSCMake.psd1
@@ -69,7 +69,7 @@ FormatsToProcess = @('PSCMake.Format.ps1xml')
 # NestedModules = @()
 
 # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
-FunctionsToExport = 'Build-CMakeBuild', 'Configure-CMakeBuild', 'Get-CMakeIncludes', 'Get-CMakePreprocess', 'Write-CMakeBuild', 'Invoke-CMakeOutput'
+FunctionsToExport = 'Build-CMakeBuild', 'Configure-CMakeBuild', 'Get-CMakeInclude', 'Get-CMakePreprocess', 'Write-CMakeBuild', 'Invoke-CMakeOutput'
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
 CmdletsToExport = @()

--- a/PSCMake/PSCMake.psm1
+++ b/PSCMake/PSCMake.psm1
@@ -618,7 +618,7 @@ function Invoke-CMakeOutput {
     Recompiles a single source file and returns the include tree captured by the compiler.
 
     .Description
-    `Get-CMakeIncludes` recompiles the given source file with include reporting enabled (/showIncludes for MSVC,
+    `Get-CMakeInclude` recompiles the given source file with include reporting enabled (/showIncludes for MSVC,
     -H for Clang) and returns the include tree as a flat list of objects with Depth and Path properties. The
     compile flags, include paths, and defines are read from the CMake File API code model for the given preset
     and configuration, so no manual compiler invocation is needed.
@@ -637,13 +637,13 @@ function Invoke-CMakeOutput {
 
     .Example
     # Show all headers included when compiling MyFile.cpp for the windows-x64 preset.
-    Get-CMakeIncludes -Preset windows-x64 -Configuration Debug -SourceFile src/MyFile.cpp
+    Get-CMakeInclude -Preset windows-x64 -Configuration Debug -SourceFile src/MyFile.cpp
 
     .Example
     # Find the deepest include chains for a file.
-    Get-CMakeIncludes windows-x64 Debug src/MyFile.cpp | Sort-Object Depth -Descending | Select-Object -First 10
+    Get-CMakeInclude windows-x64 Debug src/MyFile.cpp | Sort-Object Depth -Descending | Select-Object -First 10
 #>
-function Get-CMakeIncludes {
+function Get-CMakeInclude {
     [CmdletBinding()]
     param(
         [Parameter(Position = 0)]
@@ -668,7 +668,7 @@ function Get-CMakeIncludes {
         Write-Error "No code model found in '$BinaryDirectory'. Run Configure-CMakeBuild first."
     }
 
-    $Toolchains = Get-CMakeBuildToolchains $BinaryDirectory
+    $Toolchains = Get-CMakeBuildToolchain $BinaryDirectory
     if (-not $Toolchains) {
         Write-Error "No toolchain information found in '$BinaryDirectory'. Run Configure-CMakeBuild first."
     }
@@ -691,16 +691,16 @@ function Get-CMakeIncludes {
         $CompilerArgs += @('-H', '-c', $SourceFilePath, '-fsyntax-only')
     }
 
-    Write-Verbose "Get-CMakeIncludes: Compiler ID: $($Invocation.CompilerId)"
-    Write-Verbose "Get-CMakeIncludes: Compiler : $($Invocation.CompilerPath)"
-    Write-Verbose "Get-CMakeIncludes: Arguments: $($CompilerArgs -join ' ')"
+    Write-Verbose "Get-CMakeInclude: Compiler ID: $($Invocation.CompilerId)"
+    Write-Verbose "Get-CMakeInclude: Compiler : $($Invocation.CompilerPath)"
+    Write-Verbose "Get-CMakeInclude: Arguments: $($CompilerArgs -join ' ')"
 
     $Output = Using-Location $Invocation.BuildDir {
         InvokeExecutable $Invocation.CompilerPath $CompilerArgs 2>&1
     }
 
     if ((Test-Path variable:LASTEXITCODE) -and ($LASTEXITCODE -ne 0)) {
-        Write-Warning "Get-CMakeIncludes: Compiler exited with code $LASTEXITCODE. Include information may be incomplete."
+        Write-Warning "Get-CMakeInclude: Compiler exited with code $LASTEXITCODE. Include information may be incomplete."
     }
 
     if ($Invocation.CompilerId -eq 'MSVC') {
@@ -762,7 +762,7 @@ function Get-CMakePreprocess {
         Write-Error "No code model found in '$BinaryDirectory'. Run Configure-CMakeBuild first."
     }
 
-    $Toolchains = Get-CMakeBuildToolchains $BinaryDirectory
+    $Toolchains = Get-CMakeBuildToolchain $BinaryDirectory
     if (-not $Toolchains) {
         Write-Error "No toolchain information found in '$BinaryDirectory'. Run Configure-CMakeBuild first."
     }
@@ -811,5 +811,5 @@ Register-ArgumentCompleter -CommandName Configure-CMakeBuild -ParameterName Pres
 Register-ArgumentCompleter -CommandName Write-CMakeBuild -ParameterName Preset -ScriptBlock $function:BuildPresetsCompleter
 Register-ArgumentCompleter -CommandName Write-CMakeBuild -ParameterName Configuration -ScriptBlock $function:BuildConfigurationsCompleter
 
-Register-ArgumentCompleter -CommandName Get-CMakeIncludes -ParameterName Preset -ScriptBlock $function:BuildPresetsCompleter
-Register-ArgumentCompleter -CommandName Get-CMakeIncludes -ParameterName Configuration -ScriptBlock $function:BuildConfigurationsCompleter
+Register-ArgumentCompleter -CommandName Get-CMakeInclude -ParameterName Preset -ScriptBlock $function:BuildPresetsCompleter
+Register-ArgumentCompleter -CommandName Get-CMakeInclude -ParameterName Configuration -ScriptBlock $function:BuildConfigurationsCompleter

--- a/PSCMake/PSCMake.psm1
+++ b/PSCMake/PSCMake.psm1
@@ -318,7 +318,7 @@ function Configure-CMakeBuild {
 
     .Parameter Target
     One or more CMake target names to build. Supports wildcards. If none is specified the default targets are
-    built, or — when the current directory is a subfolder of the CMake root — the targets whose source
+    built, or - when the current directory is a subfolder of the CMake root - the targets whose source
     directory falls under the current directory.
 
     .Parameter Configure

--- a/Tests/Get-CMakeInclude.Tests.ps1
+++ b/Tests/Get-CMakeInclude.Tests.ps1
@@ -96,15 +96,15 @@ Describe 'ParseClangIncludes' {
     }
 }
 
-Describe 'Get-CMakeBuildToolchains' {
+Describe 'Get-CMakeBuildToolchain' {
     It 'Returns toolchain data from the reference build' {
-        $Toolchains = Get-CMakeBuildToolchains $script:Props.BinaryDirectory
+        $Toolchains = Get-CMakeBuildToolchain $script:Props.BinaryDirectory
         $Toolchains | Should -Not -BeNullOrEmpty
         $Toolchains.toolchains | Should -Not -BeNullOrEmpty
     }
 
     It 'Exposes a CXX toolchain with MSVC compiler' {
-        $Toolchains = Get-CMakeBuildToolchains $script:Props.BinaryDirectory
+        $Toolchains = Get-CMakeBuildToolchain $script:Props.BinaryDirectory
         $CxxToolchain = $Toolchains.toolchains | Where-Object { $_.language -eq 'CXX' }
         $CxxToolchain | Should -Not -BeNullOrEmpty
         $CxxToolchain.compiler.id | Should -Be 'MSVC'
@@ -135,7 +135,7 @@ Describe 'GetCompileInfoForSource' {
     }
 }
 
-Describe 'Get-CMakeIncludes' {
+Describe 'Get-CMakeInclude' {
     BeforeAll {
         Import-Module -Force $PSScriptRoot/../PSCMake/PSCMake.psd1 -DisableNameChecking
 
@@ -157,7 +157,7 @@ Describe 'Get-CMakeIncludes' {
 
     It 'Returns include nodes for a source file' {
         Using-Location "$PSScriptRoot/ReferenceBuild" {
-            $Result = Get-CMakeIncludes -Preset windows-x64 -Configuration Debug -SourceFile Reference.cpp
+            $Result = Get-CMakeInclude -Preset windows-x64 -Configuration Debug -SourceFile Reference.cpp
             $Result | Should -HaveCount 2
             $Result[0].Depth | Should -Be 1
             $Result[1].Depth | Should -Be 2
@@ -166,14 +166,14 @@ Describe 'Get-CMakeIncludes' {
 
     It 'Returns nodes typed as PSCMake.IncludeNode' {
         Using-Location "$PSScriptRoot/ReferenceBuild" {
-            $Result = Get-CMakeIncludes -Preset windows-x64 -Configuration Debug -SourceFile Reference.cpp
+            $Result = Get-CMakeInclude -Preset windows-x64 -Configuration Debug -SourceFile Reference.cpp
             $Result[0].PSObject.TypeNames | Should -Contain 'PSCMake.IncludeNode'
         }
     }
 
     It 'Passes /showIncludes and /nologo to the MSVC compiler' {
         Using-Location "$PSScriptRoot/ReferenceBuild" {
-            $null = Get-CMakeIncludes -Preset windows-x64 -Configuration Debug -SourceFile Reference.cpp
+            $null = Get-CMakeInclude -Preset windows-x64 -Configuration Debug -SourceFile Reference.cpp
         }
         $script:CompilerCalls | Should -HaveCount 1
         $script:CompilerCalls[0].Arguments | Should -Contain '/showIncludes'
@@ -183,7 +183,7 @@ Describe 'Get-CMakeIncludes' {
 
     It 'Invokes the compiler path from the toolchain' {
         Using-Location "$PSScriptRoot/ReferenceBuild" {
-            $null = Get-CMakeIncludes -Preset windows-x64 -Configuration Debug -SourceFile Reference.cpp
+            $null = Get-CMakeInclude -Preset windows-x64 -Configuration Debug -SourceFile Reference.cpp
         }
         $script:CompilerCalls[0].Path | Should -Match 'cl\.exe$'
     }


### PR DESCRIPTION
PowerShell cmdlets are supported to follow 'verb'-'noun' naming, and the 'noun' should be singular ([documentation](https://learn.microsoft.com/en-us/powershell/utility-modules/psscriptanalyzer/rules/usesingularnouns?view=ps-modules)). This change renames:

* `Get-CMakeIncludes` --> `Get-CMakeInclude`
* `Get-CMakeBuildToolchains` --> `Get-CMakeBuildToolchain`

