### PR TITLE
Reporting ArgumentCompleter feedback to 'host'

### DIFF
--- a/PSCMake/Common/Common.ps1
+++ b/PSCMake/Common/Common.ps1
@@ -140,3 +140,15 @@ filter ToHashTable {
     process { $Result[$_.Name] = $_.Value }
     end { $Result }
 }
+
+function GetHomePath {
+    if ($IsWindows) {
+        $env:USERPROFILE
+    } elseif ($IsLinux) {
+        $env:HOME
+    } elseif ($IsMacOS) {
+        $env:HOME
+    } else {
+        Write-Error "Unsupported platform."
+    }
+}

--- a/PSCMake/Common/Options.ps1
+++ b/PSCMake/Common/Options.ps1
@@ -1,0 +1,49 @@
+#----------------------------------------------------------------------------------------------------------------------
+# MIT License
+#
+# Copyright (c) 2025 Mark Schofield
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#----------------------------------------------------------------------------------------------------------------------
+#Requires -PSEdition Core
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+. $PSScriptRoot/Common.ps1
+
+$OptionsPath = Join-Path -Path (GetHomePath) -ChildPath '.pscmake/options.json'
+$DefaultOptions = @{
+    ArgumentCompleterFeedback = $False
+}
+$Options = $DefaultOptions
+$OptionsReadTime = $Null
+
+function LoadOptions {
+    if ((Test-Path -Path $OptionsPath) -and
+        (Get-Item -Path $OptionsPath).LastWriteTime -gt $OptionsReadTime) {
+        $CandidateOptions = Get-Content $OptionsPath |
+            ConvertFrom-Json
+        if ($CandidateOptions) {
+            $Script:Options = $CandidateOptions
+            $Script:OptionsReadTime = [datetime]::Now
+        }
+    }
+    $Script:Options
+}

--- a/PSCMake/PSCMake.psd1
+++ b/PSCMake/PSCMake.psd1
@@ -69,7 +69,14 @@ FormatsToProcess = @('PSCMake.Format.ps1xml')
 # NestedModules = @()
 
 # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
-FunctionsToExport = 'Build-CMakeBuild', 'Configure-CMakeBuild', 'Get-CMakeInclude', 'Get-CMakePreprocess', 'Write-CMakeBuild', 'Invoke-CMakeOutput'
+FunctionsToExport = @(
+    'Build-CMakeBuild'
+    'Configure-CMakeBuild'
+    'Get-CMakeInclude'
+    'Get-CMakePreprocess'
+    'Invoke-CMakeOutput'
+    'Write-CMakeBuild'
+)
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
 CmdletsToExport = @()

--- a/PSCMake/PSCMake.psm1
+++ b/PSCMake/PSCMake.psm1
@@ -30,6 +30,7 @@ $ErrorActionPreference = 'Stop'
 . $PSScriptRoot/Common/Common.ps1
 . $PSScriptRoot/Common/Includes.ps1
 . $PSScriptRoot/Common/Ninja.ps1
+. $PSScriptRoot/Common/Options.ps1
 
 <#
     .Synopsis
@@ -49,6 +50,20 @@ function InvokeExecutable {
 
 <#
     .Synopsis
+    Provides feedback during argument completion.
+#>
+function ArgumentCompleterFeedback {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWriteHost', '', Justification = 'Required by the implementation')]
+    param(
+        $Message
+    )
+    if ((LoadOptions).ArgumentCompleterFeedback -and (IsVirtualTerminalProcessingEnabled)) {
+        Write-Host -NoNewline "`eD`eD`eM`eM`e[s`n`e[0K`e[31mArgumentCompleter: $Message`e[0m`e[u"
+    }
+}
+
+<#
+    .Synopsis
     An argument-completer for `Build-CMakeBuild`'s `-Preset` parameter.
 #>
 function BuildPresetsCompleter {
@@ -63,10 +78,15 @@ function BuildPresetsCompleter {
     $null = $ParameterName
     $null = $CommandAst
     $null = $FakeBoundParameters
-    $CMakePresetsJson = GetCMakePresets -Silent
-    GetBuildPresets $CMakePresetsJson |
-        Select-Object -ExpandProperty 'name' |
-        Where-Object { $_ -ilike "$WordToComplete*" }
+    try {
+        $CMakePresetsJson = GetCMakePresets -Silent
+        GetBuildPresets $CMakePresetsJson |
+            Select-Object -ExpandProperty 'name' |
+            Where-Object { $_ -ilike "$WordToComplete*" }
+    } catch {
+        ArgumentCompleterFeedback $_
+        @('')
+    }
 }
 
 <#
@@ -91,12 +111,17 @@ function BuildConfigurationsCompleter {
     #   * If not, look for a code model and use that.
     #   * If not, look at the configure preset and see if CMAKE_CONFIGURATION_TYPES is set, and use that array.
     #   * Otherwise default to Release, Debug, RelWithDebInfo, MinSizeRel
-    @(
-        'Release'
-        'Debug'
-        'RelWithDebInfo'
-        'MinSizeRel'
-    ) | Where-Object { $_ -ilike "$WordToComplete*" }
+    try {
+        @(
+            'Release'
+            'Debug'
+            'RelWithDebInfo'
+            'MinSizeRel'
+        ) | Where-Object { $_ -ilike "$WordToComplete*" }
+    } catch {
+        ArgumentCompleterFeedback $_
+        @('')
+    }
 }
 
 <#
@@ -114,35 +139,43 @@ function BuildTargetsCompleter {
     $null = $CommandName
     $null = $ParameterName
     $null = $CommandAst
-    $CMakePresetsJson = GetCMakePresets -Silent
-    $BuildPreset = GetMatchingBuildPresets $CMakePresetsJson $FakeBoundParameters['Preset'] |
-        Select-Object -First 1
-    $ConfigurePreset = GetConfigurePresetFor $CMakePresetsJson $BuildPreset
-    $BinaryDirectory = GetBinaryDirectory $CMakePresetsJson $ConfigurePreset
-    $CMakeCodeModel = Get-CMakeBuildCodeModel $BinaryDirectory
+    try {
+        $CMakePresetsJson = GetCMakePresets -Silent
+        $BuildPreset = GetMatchingBuildPresets $CMakePresetsJson $FakeBoundParameters['Preset'] |
+            Select-Object -First 1
+        $ConfigurePreset = GetConfigurePresetFor $CMakePresetsJson $BuildPreset
+        $BinaryDirectory = GetBinaryDirectory $CMakePresetsJson $ConfigurePreset
+        $CMakeCodeModel = Get-CMakeBuildCodeModel $BinaryDirectory
+        if (-not $CMakeCodeModel) {
+            throw "Failed to get CMake code model from '$BinaryDirectory'"
+        }
 
-    # TODO: See if the $BuildPreset has a configuration.
-    $ConfigurationName = $FakeBoundParameters['Configuration'] ?? $CMakeCodeModel.configurations.Name |
-        Select-Object -First 1
-    $ConfigurationsJson = $CMakeCodeModel.configurations |
-        Where-Object -Property 'name' -EQ $ConfigurationName
-    $TargetNames = $ConfigurationsJson.targets.name
+        # TODO: See if the $BuildPreset has a configuration.
+        $ConfigurationName = $FakeBoundParameters['Configuration'] ?? $CMakeCodeModel.configurations.Name |
+            Select-Object -First 1
+        $ConfigurationsJson = $CMakeCodeModel.configurations |
+            Where-Object -Property 'name' -EQ $ConfigurationName
+        $TargetNames = $ConfigurationsJson.targets.name
 
-    # Add standard CMake targets 'all', 'clean', 'install'
-    $TargetNames += @(
-        'all'
-        'clean'
-        'install'
-    )
+        # Add standard CMake targets 'all', 'clean', 'install'
+        $TargetNames += @(
+            'all'
+            'clean'
+            'install'
+        )
 
-    # Add standard CMake target 'test' if 'CTestTestfile.cmake' exists in the binary directory.
-    $CTestFilePath = Join-Path -Path $BinaryDirectory -ChildPath 'CTestTestfile.cmake'
-    if (Test-Path -Path $CTestFilePath -PathType Leaf -ErrorAction SilentlyContinue) {
-        $TargetNames += 'test'
+        # Add standard CMake target 'test' if 'CTestTestfile.cmake' exists in the binary directory.
+        $CTestFilePath = Join-Path -Path $BinaryDirectory -ChildPath 'CTestTestfile.cmake'
+        if (Test-Path -Path $CTestFilePath -PathType Leaf -ErrorAction SilentlyContinue) {
+            $TargetNames += 'test'
+        }
+
+        $TargetNames |
+            Where-Object { $_ -ilike "$WordToComplete*" }
+    } catch {
+        ArgumentCompleterFeedback $_
+        @('')
     }
-
-    $TargetNames |
-        Where-Object { $_ -ilike "$WordToComplete*" }
 }
 
 <#
@@ -160,25 +193,33 @@ function ExecutableTargetsCompleter {
     $null = $CommandName
     $null = $ParameterName
     $null = $CommandAst
-    $CMakePresetsJson = GetCMakePresets -Silent
-    $BuildPreset = GetMatchingBuildPresets $CMakePresetsJson $FakeBoundParameters['Preset'] |
-        Select-Object -First 1
-    $ConfigurePreset = GetConfigurePresetFor $CMakePresetsJson $BuildPreset
-    $BinaryDirectory = GetBinaryDirectory $CMakePresetsJson $ConfigurePreset
-    $CMakeCodeModel = Get-CMakeBuildCodeModel $BinaryDirectory
+    try {
+        $CMakePresetsJson = GetCMakePresets -Silent
+        $BuildPreset = GetMatchingBuildPresets $CMakePresetsJson $FakeBoundParameters['Preset'] |
+            Select-Object -First 1
+        $ConfigurePreset = GetConfigurePresetFor $CMakePresetsJson $BuildPreset
+        $BinaryDirectory = GetBinaryDirectory $CMakePresetsJson $ConfigurePreset
+        $CMakeCodeModel = Get-CMakeBuildCodeModel $BinaryDirectory
+        if (-not $CMakeCodeModel) {
+            throw "Failed to get CMake code model from '$BinaryDirectory'"
+        }
 
-    # TODO: See if the $BuildPreset has a configuration.
-    $ConfigurationName = $FakeBoundParameters['Configurations'] ?? $CMakeCodeModel.configurations.Name |
-        Select-Object -First 1
-    $ConfigurationsJson = $CMakeCodeModel.configurations |
-        Where-Object -Property 'name' -EQ $ConfigurationName
+        # TODO: See if the $BuildPreset has a configuration.
+        $ConfigurationName = $FakeBoundParameters['Configurations'] ?? $CMakeCodeModel.configurations.Name |
+            Select-Object -First 1
+        $ConfigurationsJson = $CMakeCodeModel.configurations |
+            Where-Object -Property 'name' -EQ $ConfigurationName
 
-    $TargetTuplesCodeModel = $ConfigurationsJson.targets |
-        Where-Object { $_.name -ilike "$WordToComplete*" }
+        $TargetTuplesCodeModel = $ConfigurationsJson.targets |
+            Where-Object { $_.name -ilike "$WordToComplete*" }
 
-    # Use the 'code model' JSON to load the target-specific JSON to filter to targets with 'type' equal to 'EXECUTABLE'
-    $TargetTuples = FilterExecutableTargets (Get-CMakeBuildCodeModelDirectory $BinaryDirectory) $TargetTuplesCodeModel
-    $TargetTuples.name
+        # Use the 'code model' JSON to load the target-specific JSON to filter to targets with 'type' equal to 'EXECUTABLE'
+        $TargetTuples = FilterExecutableTargets (Get-CMakeBuildCodeModelDirectory $BinaryDirectory) $TargetTuplesCodeModel
+        $TargetTuples.name
+    } catch {
+        ArgumentCompleterFeedback $_
+        @('')
+    }
 }
 
 <#
@@ -197,10 +238,15 @@ function ConfigurePresetsCompleter {
     $null = $ParameterName
     $null = $CommandAst
     $null = $FakeBoundParameters
-    $CMakePresetsJson = GetCMakePresets -Silent
-    GetConfigurePresets $CMakePresetsJson |
-        Select-Object -ExpandProperty 'name' |
-        Where-Object { $_ -ilike "$WordToComplete*" }
+    try {
+        $CMakePresetsJson = GetCMakePresets -Silent
+        GetConfigurePresets $CMakePresetsJson |
+            Select-Object -ExpandProperty 'name' |
+            Where-Object { $_ -ilike "$WordToComplete*" }
+    } catch {
+        ArgumentCompleterFeedback $_
+        @('')
+    }
 }
 
 <#
@@ -404,8 +450,7 @@ function Build-CMakeBuild {
                 $Fresh -or
                 (-not (Test-Path -LiteralPath $CMakeCacheFile -PathType Leaf)) -or
                 (-not (Test-Path -LiteralPath (Get-CMakeBuildCodeModelDirectory $BinaryDirectory) -PathType Container)) -or
-                (-not ($CodeModel = Get-CMakeBuildCodeModel $BinaryDirectory))
-                ) {
+                (-not ($CodeModel = Get-CMakeBuildCodeModel $BinaryDirectory))) {
                 ConfigureCMake -CMake $CMake $CMakePresetsJson $ConfigurePreset -Fresh:$Fresh
                 $CodeModel = Get-CMakeBuildCodeModel $BinaryDirectory
             }


### PR DESCRIPTION
PowerShell's argument completers don't provide a mechanism for reporting feedback to the user, which can make the experience a bit confusing. Some implementations advocate for returning an message or sentinel value so that completer renders that, but that's not really very clear.

This PR implements an alternative - using VT escape sequences to write to the console. If an error is raised in an argument completer, the ArgumentCompleterFeedback method will report the exception to the console. It will:

1. Move the cursor down two rows, and then back up, to make sure that there's two rows of space.
2. Store the cursor position
3. Move to the next line, and clear it
4. Set the foreground color to 'red'
5. Write a message
6. Restore the foreground color
7. Restore the cursor position

Which results in the error message being written on the line following the cursor. This is - at least - a useful debugging utility, but maybe not for general use, so that functionality is behind an option; create: `~/.pscmake/options.json` and set the content to be:

```json
{
"ArgumentCompleterFeedback":true
}
```

This PR changes the result when an error occurs, too. If no value is returned from an ArgumentCompleter, then the default completer is used, which enumerates items in the current folder. Returning an array with an empty string (an empty array isn't sufficient!) will force the completer to not render any values.